### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,40 @@
+name: Publish package
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  publish-package:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Prepare version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Publish to PyPI using OIDC
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          version: ${{ env.VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,16 @@
 name: Publish package
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Select the destination'
+        required: true
+        default: 'testpypi'
+        type: choice
+        options:
+          - testpypi
+          - pypi
 
 jobs:
   publish-package:
@@ -11,6 +18,7 @@ jobs:
 
     permissions:
       id-token: write
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -29,5 +37,7 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Publish to PyPI using OIDC
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ github.event.inputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,18 +24,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.11'
+          version: "latest"
 
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
+      - name: Set up Python
+        run: uv python install 3.11
 
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Run tests
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
@@ -29,5 +28,36 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
-      - name: Run tests
-        run: pytest -vv -s --cov=work_tracker --cov-config=pyproject.toml
+      - name: Start pytest
+        run: pytest -vv -s --cov=work_tracker --cov-config=pyproject.toml --ignore=tests/e2e.py
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --editable .
+          pip install -r requirements-dev.txt
+
+      - name: Start pytest
+        run: pytest -vv -s tests/e2e.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           version: "latest"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,10 +3,10 @@ name: Run tests
 on:
   push:
     branches:
-      - "**" # run on every branch
+      - "**"
 
 jobs:
-  unit-tests:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,47 +17,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
-
-      - name: Start pytest
-        run: pytest -vv -s --cov=work_tracker --cov-config=pyproject.toml --ignore=tests/e2e.py
-
-  e2e-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-      fail-fast: false
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          enable-cache: true
+          version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+        run: uv sync --all-groups
 
-      - name: Install dependencies
+      - name: Run Unit Tests
         run: |
-          python -m pip install --upgrade pip
-          pip install --editable .
-          pip install -r requirements-dev.txt
+          uv run pytest -vv -s --cov=work_tracker --cov-config=pyproject.toml --ignore=tests/e2e.py
 
-      - name: Start pytest
-        run: pytest -vv -s tests/e2e.py
+      - name: Run E2E Tests
+        run: |
+          uv run pytest -vv -s tests/e2e.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          uv run pytest -vv -s --cov=work_tracker --cov-config=pyproject.toml --ignore=tests/e2e.py
+          uv run pytest -vv -s --cov=work_tracker --cov-config=pyproject.toml --ignore=tests/e2e.py --random-order
 
       - name: Run E2E Tests
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include README.md
+include LICENSE
+recursive-include work_tracker *.py
+
+exclude *.pyc
+exclude tests/*
+exclude MANIFEST.in
+
+recursive-exclude tests *
+
+prune .git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE
 recursive-include work_tracker *.py
+recursive-include work_tracker/data *
 
 exclude *.pyc
 exclude tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-order~=1.3.0",
     "pytest-random-order~=1.1.1",
     "pytest-cov~=6.0.0",
+    "pexpect~=4.9.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ source = "https://github.com/kiszkacy/work-tracker"
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["work_tracker"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["work_tracker*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "work_tracker.version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,21 +12,23 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Environment :: Console",
 ]
 dependencies = [
-    "workalendar~=17.0.0",
-    "pydantic~=2.10.5",
-    "appdirs~=1.4.4",
-    "path~=17.1.0",
-    "PyYAML~=6.0.2",
-    "pyperclip~=1.9.0",
-    "colorama~=0.4.6",
-    "multimethod~=2.0",
-    "prompt_toolkit~=3.0.48",
+    "workalendar>=17.0.0",
+    "pydantic>=2.10.5",
+    "appdirs>=1.4.4",
+    "path>=17.1.0",
+    "pyyaml>=6.0.2",
+    "pyperclip>=1.9.0",
+    "colorama>=0.4.6",
+    "multimethod>=2.0",
+    "prompt-toolkit>=3.0.48",
+    "packaging>=26.0",
 ]
 requires-python = ">=3.10,<4.0"
 keywords = ["work", "time", "tracker"]
@@ -34,16 +36,6 @@ dynamic = ["version"]
 
 [project.scripts]
 work-tracker = "work_tracker.main:main"
-
-[project.optional-dependencies]
-dev = [
-    "pytest~=8.3.4",
-    "pytest-mock~=3.14.0",
-    "pytest-order~=1.3.0",
-    "pytest-random-order~=1.1.1",
-    "pytest-cov~=6.0.0",
-    "pexpect~=4.9.0",
-]
 
 [project.urls]
 source = "https://github.com/kiszkacy/work-tracker"
@@ -63,3 +55,13 @@ version = {attr = "work_tracker.version.__version__"}
 include_namespace_packages = true
 omit = ["**/__init__.py"]
 skip_empty = true
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+    "pytest-mock>=3.14.0",
+    "pytest-order>=1.3.0",
+    "pytest-random-order>=1.1.1",
+    "pytest-cov>=6.0.0",
+    "pexpect>=4.9.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ include_namespace_packages = true
 omit = ["**/__init__.py"]
 skip_empty = true
 
+[tool.ruff.lint]
+ignore = ["F811"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-mock~=3.14.0
 pytest-order~=1.3.0
 pytest-random-order~=1.1.1
 pytest-cov~=6.0.0
+pexpect~=4.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-pytest~=8.3.4
-pytest-mock~=3.14.0
-pytest-order~=1.3.0
-pytest-random-order~=1.1.1
-pytest-cov~=6.0.0
-pexpect~=4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-workalendar~=17.0.0
-pydantic~=2.10.5
-appdirs~=1.4.4
-path~=17.1.0
-PyYAML~=6.0.2
-pyperclip~=1.9.0
-colorama~=0.4.6
-multimethod~=2.0
-prompt_toolkit~=3.0.48

--- a/tests/commands/test___date.py
+++ b/tests/commands/test___date.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+import pytest
+
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.common import Date
+
+
+@pytest.mark.order(1)
+def test_init(internal_date_handler):
+    assert internal_date_handler is not None
+
+
+def test_should_change_active_date_to_given_day(internal_date_handler, random_date: Date):
+    day: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[day])
+
+    assert result.change_active_date is not None
+    assert result.change_active_date.is_day_date()
+    assert result.error is None
+
+
+def test_should_change_active_date_to_given_month(internal_date_handler, random_date: Date):
+    month: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[month])
+
+    assert result.change_active_date is not None
+    assert result.change_active_date.is_month_date()
+    assert result.error is None
+
+
+def test_should_preserve_day_value_of_given_date(internal_date_handler, random_date: Date):
+    day: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[day])
+
+    assert result.change_active_date.day == day.day
+    assert result.error is None
+
+
+def test_should_preserve_month_value_of_given_month_date(internal_date_handler, random_date: Date):
+    month: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[month])
+
+    assert result.change_active_date.month == month.month
+    assert result.error is None
+
+
+def test_should_fill_partial_day_with_active_date(internal_date_handler, random_date: Date):
+    active: Date = random_date.to_day_date()
+    partial_day: Date = Date(day=1)
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[partial_day], active_date=active)
+
+    assert result.change_active_date is not None
+    assert result.change_active_date.day == 1
+    assert result.change_active_date.month == active.month
+    assert result.change_active_date.year == active.year
+    assert result.error is None
+
+
+def test_should_fill_partial_month_with_active_date(internal_date_handler, random_date: Date):
+    active: Date = random_date.to_day_date()
+    partial_month: Date = Date(month=active.month)
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[partial_month], active_date=active)
+
+    assert result.change_active_date is not None
+    assert result.change_active_date.day is None
+    assert result.change_active_date.month == active.month
+    assert result.change_active_date.year == active.year
+    assert result.error is None
+
+
+def test_should_return_error_when_no_dates_given(internal_date_handler):
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[])
+
+    assert result.error is not None
+
+
+def test_should_return_error_when_too_many_dates_given(internal_date_handler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=dates)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_argument_count(internal_date_handler, random_date: Date):
+    day: Date = random_date.to_day_date()
+    arguments: list[Any] = ["extra"]
+
+    result: CommandHandlerResult = handle_call(internal_date_handler, dates=[day], arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test___macro.py
+++ b/tests/commands/test___macro.py
@@ -1,0 +1,162 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.command.common import TimeArgument, TimeArgumentType
+from work_tracker.command.macro_manager import MacroManager, MacroTemplate
+from work_tracker.common import Date
+
+
+@pytest.fixture(autouse=True)
+def isolate_macro_state(mocker: MockerFixture):
+    _ = MacroManager.macros  # ensure manager is initialized before test
+    original_macros: dict = dict(MacroManager._macros)
+    mocker.patch.object(MacroManager, "save_macros_file")  # do not save to file during tests
+    yield  # run test
+    MacroManager._macros = original_macros
+
+
+@pytest.mark.order(1)
+def test_init(internal_macro_handler):
+    assert internal_macro_handler is not None
+
+
+def test_should_expand_no_argument_macro_and_return_execute_after_queries(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro | remote",
+        command_text="remote",
+        arguments=[],
+        default_argument_values=[],
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["mymacro"])
+
+    assert result.execute_after is not None
+    assert len(result.execute_after) > 0
+    assert result.error is None
+
+
+def test_should_substitute_required_argument_into_macro(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro <arg> | <arg>",
+        command_text="<arg>",
+        arguments=["arg"],
+        default_argument_values=[None],
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["mymacro", "remote"])
+
+    assert result.execute_after is not None
+    assert len(result.execute_after) > 0
+    assert result.error is None
+
+
+def test_should_use_default_argument_when_not_provided(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro <arg=remote> | <arg>",
+        command_text="<arg>",
+        arguments=["arg"],
+        default_argument_values=["remote"],
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["mymacro"])
+
+    assert result.execute_after is not None
+    assert len(result.execute_after) > 0
+    assert result.error is None
+
+
+def test_should_override_default_argument_when_provided(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro <arg=remote> | <arg>",
+        command_text="<arg>",
+        arguments=["arg"],
+        default_argument_values=["remote"],
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["mymacro", "office"])
+
+    assert result.execute_after is not None
+    assert len(result.execute_after) > 0
+    assert result.error is None
+
+
+def test_should_substitute_time_argument_into_macro(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["workmacro"] = MacroTemplate(
+        identifier="workmacro",
+        raw="workmacro <time> | <time>",
+        command_text="<time>",
+        arguments=["time"],
+        default_argument_values=[None],
+    )
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["workmacro", time_arg])
+
+    assert result.execute_after is not None
+    assert len(result.execute_after) > 0
+    assert result.error is None
+
+
+def test_should_return_error_on_no_arguments(internal_macro_handler):
+    result: CommandHandlerResult = handle_call(internal_macro_handler, arguments=[])
+
+    assert result.error is not None
+
+
+def test_should_return_error_when_too_many_arguments_provided(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["noargsmacro"] = MacroTemplate(
+        identifier="noargsmacro",
+        raw="noargsmacro | remote",
+        command_text="remote",
+        arguments=[],
+        default_argument_values=[],
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["noargsmacro", "extra"])
+
+    assert result.error is not None
+
+
+def test_should_return_error_when_required_argument_is_missing(internal_macro_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["requiredmacro"] = MacroTemplate(
+        identifier="requiredmacro",
+        raw="requiredmacro <arg> | <arg>",
+        command_text="<arg>",
+        arguments=["arg"],
+        default_argument_values=[None],  # required, no default
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, active_date=date, arguments=["requiredmacro"])
+
+    assert result.error is not None
+
+
+def test_should_forward_explicit_dates_to_execute_after_queries(internal_macro_handler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro | remote",
+        command_text="remote",
+        arguments=[],
+        default_argument_values=[],
+    )
+
+    result: CommandHandlerResult = handle_call(internal_macro_handler, dates=dates, arguments=["mymacro"])
+
+    assert result.execute_after is not None
+    assert len(result.execute_after) > 0
+    assert result.execute_after[0].dates == dates
+    assert result.error is None

--- a/tests/commands/test___time.py
+++ b/tests/commands/test___time.py
@@ -1,0 +1,157 @@
+import pytest
+
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.command.common import TimeArgument, TimeArgumentType
+from work_tracker.common import Date
+
+
+@pytest.mark.order(1)
+def test_init(internal_time_handler):
+    assert internal_time_handler is not None
+
+
+def test_should_overwrite_minutes_at_work_for_active_day(internal_time_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    internal_time_handler.data.day[date].minutes_at_work = 100
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=date, arguments=[time_arg])
+
+    assert internal_time_handler.data.day[date].minutes_at_work == 480
+    assert result.error is None
+
+
+def test_should_add_to_minutes_at_work_for_active_day(internal_time_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    internal_time_handler.data.day[date].minutes_at_work = 100
+    time_arg: TimeArgument = TimeArgument(minutes=60, type=TimeArgumentType.Add)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=date, arguments=[time_arg])
+
+    assert internal_time_handler.data.day[date].minutes_at_work == 160
+    assert result.error is None
+
+
+def test_should_subtract_from_minutes_at_work_for_active_day(internal_time_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    internal_time_handler.data.day[date].minutes_at_work = 200
+    time_arg: TimeArgument = TimeArgument(minutes=60, type=TimeArgumentType.Subtract)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=date, arguments=[time_arg])
+
+    assert internal_time_handler.data.day[date].minutes_at_work == 140
+    assert result.error is None
+
+
+def test_should_update_day_target_when_minutes_exceed_target(internal_time_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    internal_time_handler.data.day[date].target_minutes = 480
+    internal_time_handler.data.day[date].minutes_at_work = 0
+    time_arg: TimeArgument = TimeArgument(minutes=600, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=date, arguments=[time_arg])
+
+    assert internal_time_handler.data.day[date].minutes_at_work == 600
+    assert internal_time_handler.data.day[date].target_minutes == 600
+    assert result.error is None
+
+
+def test_should_keep_day_target_tracking_minutes_when_they_were_equal(internal_time_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    internal_time_handler.data.day[date].target_minutes = 480
+    internal_time_handler.data.day[date].minutes_at_work = 480
+    time_arg: TimeArgument = TimeArgument(minutes=300, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=date, arguments=[time_arg])
+
+    assert internal_time_handler.data.day[date].minutes_at_work == 300
+    assert internal_time_handler.data.day[date].target_minutes == 300
+    assert result.error is None
+
+
+def test_should_not_update_day_target_when_below_target(internal_time_handler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    internal_time_handler.data.day[date].target_minutes = 480
+    internal_time_handler.data.day[date].minutes_at_work = 0
+    time_arg: TimeArgument = TimeArgument(minutes=300, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=date, arguments=[time_arg])
+
+    assert internal_time_handler.data.day[date].minutes_at_work == 300
+    assert internal_time_handler.data.day[date].target_minutes == 480
+    assert result.error is None
+
+
+def test_should_update_month_target_minutes(internal_time_handler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    internal_time_handler.data.month[month].target_minutes = 9600
+    time_arg: TimeArgument = TimeArgument(minutes=4800, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=month, arguments=[time_arg])
+
+    assert internal_time_handler.data.month[month].target_minutes == 4800
+    assert result.error is None
+
+
+def test_should_add_to_month_target_minutes(internal_time_handler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    internal_time_handler.data.month[month].target_minutes = 9600
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Add)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=month, arguments=[time_arg])
+
+    assert internal_time_handler.data.month[month].target_minutes == 10080
+    assert result.error is None
+
+
+def test_should_subtract_from_month_target_minutes(internal_time_handler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    internal_time_handler.data.month[month].target_minutes = 9600
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Subtract)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, active_date=month, arguments=[time_arg])
+
+    assert internal_time_handler.data.month[month].target_minutes == 9120
+    assert result.error is None
+
+
+def test_should_overwrite_minutes_for_given_days(internal_time_handler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        internal_time_handler.data.day[date].minutes_at_work = 0
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, dates=dates, arguments=[time_arg])
+
+    for date in dates:
+        assert internal_time_handler.data.day[date].minutes_at_work == 480
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_overwrite_target_for_given_months(internal_time_handler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        internal_time_handler.data.month[month].target_minutes = 9600
+    time_arg: TimeArgument = TimeArgument(minutes=4800, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, dates=months, arguments=[time_arg])
+
+    for month in months:
+        assert internal_time_handler.data.month[month].target_minutes == 4800
+    assert result.error is None
+
+
+def test_should_return_error_on_no_arguments(internal_time_handler):
+    result: CommandHandlerResult = handle_call(internal_time_handler)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(internal_time_handler):
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(internal_time_handler, arguments=[time_arg, time_arg])
+
+    assert result.error is not None

--- a/tests/commands/test_absence.py
+++ b/tests/commands/test_absence.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.absence import AbsenceHandler
+
+
+@pytest.mark.order(1)
+def test_init(absence_handler: AbsenceHandler):
+    assert absence_handler is not None

--- a/tests/commands/test_absence.py
+++ b/tests/commands/test_absence.py
@@ -1,8 +1,72 @@
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.absence import AbsenceHandler
+from work_tracker.common import AttendanceType, Date, DayType
 
 
 @pytest.mark.order(1)
 def test_init(absence_handler: AbsenceHandler):
     assert absence_handler is not None
+
+
+def test_should_set_to_absence_active_day(absence_handler: AbsenceHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    absence_handler.data.day[date].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(absence_handler, active_date=date)
+
+    assert absence_handler.data.day[date].attendance_type == AttendanceType.ABSENCE
+    assert result.error is None
+
+
+def test_should_set_to_absence_active_month_workdays(absence_handler: AbsenceHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        absence_handler.data.day[day].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(absence_handler, active_date=month)
+
+    for day in [day for day in month.days_in_a_month() if absence_handler.data.day[day].day_type == DayType.WORKDAY]:
+        assert absence_handler.data.day[day].attendance_type == AttendanceType.ABSENCE
+    for day in [day for day in month.days_in_a_month() if absence_handler.data.day[day].day_type != DayType.WORKDAY]:
+        assert absence_handler.data.day[day].attendance_type != AttendanceType.ABSENCE
+    assert result.error is None
+
+
+def test_should_set_to_absence_given_days(absence_handler: AbsenceHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        absence_handler.data.day[date].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(absence_handler, dates=dates)
+
+    for date in dates:
+        assert absence_handler.data.day[date].attendance_type == AttendanceType.ABSENCE
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_to_absence_given_months_workdays(absence_handler: AbsenceHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            absence_handler.data.day[day].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(absence_handler, dates=months)
+
+    for month in months:
+        for day in [day for day in month.days_in_a_month() if absence_handler.data.day[day].day_type == DayType.WORKDAY]:
+            assert absence_handler.data.day[day].attendance_type == AttendanceType.ABSENCE
+        for day in [day for day in month.days_in_a_month() if absence_handler.data.day[day].day_type != DayType.WORKDAY]:
+            assert absence_handler.data.day[day].attendance_type != AttendanceType.ABSENCE
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(absence_handler: AbsenceHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(absence_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_absence.py
+++ b/tests/commands/test_absence.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import handle_call
@@ -65,7 +67,7 @@ def test_should_set_to_absence_given_months_workdays(absence_handler: AbsenceHan
 
 
 def test_should_return_error_on_invalid_argument_count(absence_handler: AbsenceHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(absence_handler, arguments=arguments)
 

--- a/tests/commands/test_alias.py
+++ b/tests/commands/test_alias.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.alias import AliasHandler
+
+
+@pytest.mark.order(1)
+def test_init(alias_handler: AliasHandler):
+    assert alias_handler is not None

--- a/tests/commands/test_alias.py
+++ b/tests/commands/test_alias.py
@@ -1,8 +1,107 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.alias import AliasHandler
+from work_tracker.command.alias_manager import AliasManager, AliasTemplate
+from work_tracker.common import Date
+
+
+@pytest.fixture(autouse=True)
+def isolate_alias_state(mocker: MockerFixture):
+    _ = AliasManager.aliases # lazy-load aliases
+    original_aliases: dict = dict(AliasManager._aliases)
+    mocker.patch.object(AliasManager, "save_aliases_file") # do not save to file during tests
+    yield # run test
+    AliasManager._aliases = original_aliases
 
 
 @pytest.mark.order(1)
 def test_init(alias_handler: AliasHandler):
     assert alias_handler is not None
+
+
+def test_should_output_alias_list(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_specific_alias(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    test_alias: AliasTemplate = AliasTemplate(
+        identifier="testalias",
+        raw="testalias | remote",
+        replacement_text="remote",
+    )
+    AliasManager._aliases["testalias"] = test_alias
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date, arguments=["testalias"])
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "testalias" in output
+    assert result.error is None
+
+
+def test_should_output_message_for_nonexistent_alias(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date, arguments=["nonexistentalias"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_create_new_alias(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date, arguments=["myalias", "remote"])
+
+    assert "myalias" in AliasManager.aliases
+    assert AliasManager.aliases["myalias"].replacement_text == "remote"
+    assert result.error is None
+
+
+def test_should_update_existing_alias(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    AliasManager._aliases["myalias"] = AliasTemplate(
+        identifier="myalias",
+        raw="myalias | office",
+        replacement_text="office",
+    )
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date, arguments=["myalias", "remote"])
+
+    assert AliasManager.aliases["myalias"].replacement_text == "remote"
+    assert result.error is None
+
+
+def test_should_reject_reserved_identifier_alias(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date, arguments=["alias", "remote"])
+
+    assert "alias" not in AliasManager.aliases
+    assert result.error is None
+
+
+def test_should_reject_reserved_identifier_deletealias(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(alias_handler, active_date=date, arguments=["deletealias", "remote"])
+
+    assert "deletealias" not in AliasManager.aliases
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_date_count(alias_handler: AliasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(alias_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_calendar.py
+++ b/tests/commands/test_calendar.py
@@ -1,0 +1,81 @@
+import pytest
+
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.command.commands.calendar import CalendarHandler
+from work_tracker.common import Mode, Date
+
+
+@pytest.mark.order(1)
+def test_init(calendar_handler: CalendarHandler):
+    assert calendar_handler is not None
+
+
+def test_should_output_calendar(calendar_handler: CalendarHandler):
+    result: CommandHandlerResult = handle_call(calendar_handler)
+
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(calendar_handler: CalendarHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(calendar_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date(calendar_handler: CalendarHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(calendar_handler, dates=[date])
+
+    assert result.error is not None
+
+
+def test_should_work_on_valid_date(calendar_handler: CalendarHandler, random_date: Date):
+    date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(calendar_handler, dates=[date])
+
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_work_with_many_valid_dates(calendar_handler: CalendarHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_month_date() for date in random_dates]
+
+    result: CommandHandlerResult = handle_call(calendar_handler, dates=dates)
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None
+
+
+def test_should_work_in_today_mode(calendar_handler: CalendarHandler):
+    mode: Mode = Mode.Today
+
+    result: CommandHandlerResult = handle_call(calendar_handler, mode=mode)
+
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None
+
+
+def test_should_work_in_day_mode(calendar_handler: CalendarHandler, random_date: Date):
+    mode: Mode = Mode.Day
+    active_date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(calendar_handler, mode=mode, active_date=active_date)
+
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None
+
+
+def test_should_work_in_month_mode(calendar_handler: CalendarHandler, random_date: Date):
+    mode: Mode = Mode.Month
+    active_date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(calendar_handler, mode=mode, active_date=active_date)
+
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None

--- a/tests/commands/test_calendar.py
+++ b/tests/commands/test_calendar.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import handle_call, TestInputOutput
@@ -19,7 +21,7 @@ def test_should_output_calendar(calendar_handler: CalendarHandler):
 
 
 def test_should_return_error_on_invalid_argument_count(calendar_handler: CalendarHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(calendar_handler, arguments=arguments)
 

--- a/tests/commands/test_checkpoint.py
+++ b/tests/commands/test_checkpoint.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.checkpoint import CheckpointHandler
+
+
+@pytest.mark.order(1)
+def test_init(checkpoint_handler: CheckpointHandler):
+    assert checkpoint_handler is not None

--- a/tests/commands/test_checkpoint.py
+++ b/tests/commands/test_checkpoint.py
@@ -1,8 +1,98 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.checkpoint_manager import CheckpointManager, CheckpointTemplate
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.checkpoint import CheckpointHandler
+from work_tracker.common import Date
+from path import Path
+
+
+@pytest.fixture()
+def fake_checkpoint() -> CheckpointTemplate:
+    return CheckpointTemplate(
+        path=Path("."),
+        full_identifier="user.test-checkpoint__2026-03-18_11-00-00",
+        name="user.test-checkpoint",
+        date="2026-03-18_11-00-00",
+        persistent=True,
+    )
 
 
 @pytest.mark.order(1)
 def test_init(checkpoint_handler: CheckpointHandler):
     assert checkpoint_handler is not None
+
+
+def test_should_output_no_checkpoints_message_when_empty(checkpoint_handler: CheckpointHandler, mocker: MockerFixture, random_date: Date):
+    date: Date = random_date.to_day_date()
+    mocker.patch.object(CheckpointManager, "checkpoints", return_value=[])
+
+    result: CommandHandlerResult = handle_call(checkpoint_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert result.error is None
+
+
+def test_should_output_checkpoint_list_when_checkpoints_exist(
+    checkpoint_handler: CheckpointHandler,
+    mocker: MockerFixture,
+    random_date: Date,
+    fake_checkpoint: CheckpointTemplate,
+):
+    date: Date = random_date.to_day_date()
+    mocker.patch.object(CheckpointManager, "checkpoints", return_value=[fake_checkpoint])
+    mocker.patch("os.path.getctime", return_value=0.0)
+
+    result: CommandHandlerResult = handle_call(checkpoint_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "test-checkpoint" in output
+    assert result.error is None
+
+
+def test_should_create_temporary_checkpoint(checkpoint_handler: CheckpointHandler, mocker: MockerFixture, random_date: Date):
+    date: Date = random_date.to_day_date()
+    mock_save = mocker.patch.object(CheckpointManager, "save")
+
+    result: CommandHandlerResult = handle_call(checkpoint_handler, active_date=date, arguments=["mycheckpoint"])
+
+    mock_save.assert_called_once()
+    assert result.error is None
+
+
+def test_should_create_permanent_checkpoint(checkpoint_handler: CheckpointHandler, mocker: MockerFixture, random_date: Date):
+    date: Date = random_date.to_day_date()
+    mock_save = mocker.patch.object(CheckpointManager, "save")
+
+    result: CommandHandlerResult = handle_call(checkpoint_handler, active_date=date, arguments=["mycheckpoint", "permanent"])
+
+    mock_save.assert_called_once()
+    _, kwargs = mock_save.call_args
+    assert kwargs.get("persistent_checkpoint") is True
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_permanent_argument(checkpoint_handler: CheckpointHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(checkpoint_handler, active_date=date, arguments=["mycheckpoint", "invalidargument"])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(checkpoint_handler: CheckpointHandler):
+    result: CommandHandlerResult = handle_call(checkpoint_handler, arguments=["test-checkpoint", "permanent", "extra"])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(checkpoint_handler: CheckpointHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(checkpoint_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_clear.py
+++ b/tests/commands/test_clear.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import handle_call
@@ -61,7 +63,7 @@ def test_should_clear_given_months(clear_handler: ClearHandler, random_dates: li
 
 
 def test_should_return_error_on_invalid_argument_count(clear_handler: ClearHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(clear_handler, arguments=arguments)
 

--- a/tests/commands/test_clear.py
+++ b/tests/commands/test_clear.py
@@ -13,7 +13,6 @@ def test_init(clear_handler: ClearHandler):
 
 def test_should_clear_active_day(clear_handler: ClearHandler, random_date: Date):
     date: Date = random_date.to_day_date()
-
     clear_handler.data.day[date].minutes_at_work = 1 # TODO this theoretically should be enough to check if date was cleared/resetted
 
     result: CommandHandlerResult = handle_call(clear_handler, active_date=date)
@@ -24,7 +23,6 @@ def test_should_clear_active_day(clear_handler: ClearHandler, random_date: Date)
 
 def test_should_clear_active_month(clear_handler: ClearHandler, random_date: Date):
     month: Date = random_date.to_month_date()
-
     for day in month.days_in_a_month():
         clear_handler.data.day[day].minutes_at_work = 1
 
@@ -37,7 +35,6 @@ def test_should_clear_active_month(clear_handler: ClearHandler, random_date: Dat
 
 def test_should_clear_given_days(clear_handler: ClearHandler, random_dates: list[Date]):
     dates: list[Date] = [date.to_day_date() for date in random_dates]
-
     for date in dates:
         clear_handler.data.day[date].minutes_at_work = 1
 
@@ -51,7 +48,6 @@ def test_should_clear_given_days(clear_handler: ClearHandler, random_dates: list
 @pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
 def test_should_clear_given_months(clear_handler: ClearHandler, random_dates: list[Date]):
     months: list[Date] = [date.to_month_date() for date in random_dates]
-
     for month in months:
         for day in month.days_in_a_month():
             clear_handler.data.day[day].minutes_at_work = 1

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,8 +1,85 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.config import ConfigHandler
+from work_tracker.config import Config, MainConfig
+from work_tracker.common import Date
+
+
+@pytest.fixture(autouse=True)
+def isolate_config_state(mocker: MockerFixture):
+    _ = Config.data # lazy-load config
+    original_config: MainConfig = Config._data.model_copy()
+    mocker.patch.object(Config, "save") # do not save to file during tests
+    yield # run test
+    Config._data = original_config
 
 
 @pytest.mark.order(1)
 def test_init(config_handler: ConfigHandler):
     assert config_handler is not None
+
+
+def test_should_output_all_config_fields(config_handler: ConfigHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(config_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_specific_config_field(config_handler: ConfigHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(config_handler, active_date=date, arguments=["output.max_width"])
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert str(Config.data.output.max_width) in output
+    assert result.error is None
+
+
+def test_should_output_message_for_nonexistent_field(config_handler: ConfigHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(config_handler, active_date=date, arguments=["nonexistent.field"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_update_config_field(config_handler: ConfigHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    original_value: int = Config.data.output.max_width
+    new_value: int = original_value + 10
+
+    result: CommandHandlerResult = handle_call(config_handler, active_date=date, arguments=["output.max_width", new_value])
+
+    assert Config.data.output.max_width == new_value
+    assert result.error is None
+
+
+def test_should_not_update_version_field(config_handler: ConfigHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(config_handler, active_date=date, arguments=["version", 999])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_too_many_arguments(config_handler: ConfigHandler):
+    result: CommandHandlerResult = handle_call(config_handler, arguments=["field", "value", "extra"])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(config_handler: ConfigHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(config_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.config import ConfigHandler
+
+
+@pytest.mark.order(1)
+def test_init(config_handler: ConfigHandler):
+    assert config_handler is not None

--- a/tests/commands/test_dayoff.py
+++ b/tests/commands/test_dayoff.py
@@ -1,8 +1,72 @@
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.dayoff import DayoffHandler
+from work_tracker.common import AttendanceType, Date, DayType
 
 
 @pytest.mark.order(1)
 def test_init(dayoff_handler: DayoffHandler):
     assert dayoff_handler is not None
+
+
+def test_should_set_to_dayoff_active_day(dayoff_handler: DayoffHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    dayoff_handler.data.day[date].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(dayoff_handler, active_date=date)
+
+    assert dayoff_handler.data.day[date].attendance_type == AttendanceType.DAYOFF
+    assert result.error is None
+
+
+def test_should_set_to_dayoff_active_month_workdays(dayoff_handler: DayoffHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        dayoff_handler.data.day[day].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(dayoff_handler, active_date=month)
+
+    for day in [day for day in month.days_in_a_month() if dayoff_handler.data.day[day].day_type == DayType.WORKDAY]:
+        assert dayoff_handler.data.day[day].attendance_type == AttendanceType.DAYOFF
+    for day in [day for day in month.days_in_a_month() if dayoff_handler.data.day[day].day_type != DayType.WORKDAY]:
+        assert dayoff_handler.data.day[day].attendance_type != AttendanceType.DAYOFF
+    assert result.error is None
+
+
+def test_should_set_to_dayoff_given_days(dayoff_handler: DayoffHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        dayoff_handler.data.day[date].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(dayoff_handler, dates=dates)
+
+    for date in dates:
+        assert dayoff_handler.data.day[date].attendance_type == AttendanceType.DAYOFF
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_to_dayoff_given_months_workdays(dayoff_handler: DayoffHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            dayoff_handler.data.day[day].attendance_type = AttendanceType.PRESENT
+
+    result: CommandHandlerResult = handle_call(dayoff_handler, dates=months)
+
+    for month in months:
+        for day in [day for day in month.days_in_a_month() if dayoff_handler.data.day[day].day_type == DayType.WORKDAY]:
+            assert dayoff_handler.data.day[day].attendance_type == AttendanceType.DAYOFF
+        for day in [day for day in month.days_in_a_month() if dayoff_handler.data.day[day].day_type != DayType.WORKDAY]:
+            assert dayoff_handler.data.day[day].attendance_type != AttendanceType.DAYOFF
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(dayoff_handler: DayoffHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(dayoff_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_dayoff.py
+++ b/tests/commands/test_dayoff.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.dayoff import DayoffHandler
+
+
+@pytest.mark.order(1)
+def test_init(dayoff_handler: DayoffHandler):
+    assert dayoff_handler is not None

--- a/tests/commands/test_dayoff.py
+++ b/tests/commands/test_dayoff.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import handle_call
@@ -65,7 +67,7 @@ def test_should_set_to_dayoff_given_months_workdays(dayoff_handler: DayoffHandle
 
 
 def test_should_return_error_on_invalid_argument_count(dayoff_handler: DayoffHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(dayoff_handler, arguments=arguments)
 

--- a/tests/commands/test_days.py
+++ b/tests/commands/test_days.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.days import DaysHandler
+
+
+@pytest.mark.order(1)
+def test_init(days_handler: DaysHandler):
+    assert days_handler is not None

--- a/tests/commands/test_days.py
+++ b/tests/commands/test_days.py
@@ -1,8 +1,117 @@
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.days import DaysHandler
+from work_tracker.command.common import TimeArgument, TimeArgumentType
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(days_handler: DaysHandler):
     assert days_handler is not None
+
+
+def test_should_output_days_count_for_active_date(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    days_handler.data.month[date.to_month_date()].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=[time_arg])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_output_days_count_for_given_months(days_handler: DaysHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    for month in months:
+        days_handler.data.month[month].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(days_handler, dates=months, arguments=[time_arg])
+
+    for _ in months:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_office_days_count(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    days_handler.data.month[date.to_month_date()].target_minutes = 9600
+    days_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=["office", time_arg])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_remote_days_count(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    days_handler.data.month[date.to_month_date()].target_minutes = 9600
+    days_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=["remote", time_arg])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_clean_days_count_excluding_filled_dates(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    days_handler.data.month[date.to_month_date()].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=[time_arg, "clean"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_office_clean_days_count(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    days_handler.data.month[date.to_month_date()].target_minutes = 9600
+    days_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=["office", time_arg, "clean"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_no_arguments(days_handler: DaysHandler):
+    result: CommandHandlerResult = handle_call(days_handler)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_zero_minutes(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    zero_time_arg: TimeArgument = TimeArgument(minutes=0, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=[zero_time_arg])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_location_argument(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=["invalid", time_arg])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_clean_argument(days_handler: DaysHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(days_handler, active_date=date, arguments=[time_arg, "invalid"])
+
+    assert result.error is not None

--- a/tests/commands/test_deletealias.py
+++ b/tests/commands/test_deletealias.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.deletealias import DeletealiasHandler
+
+
+@pytest.mark.order(1)
+def test_init(deletealias_handler: DeletealiasHandler):
+    assert deletealias_handler is not None

--- a/tests/commands/test_deletealias.py
+++ b/tests/commands/test_deletealias.py
@@ -1,8 +1,57 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.deletealias import DeletealiasHandler
+from work_tracker.command.alias_manager import AliasManager, AliasTemplate
+from work_tracker.common import Date
+
+
+@pytest.fixture(autouse=True)
+def isolate_alias_state(mocker: MockerFixture):
+    _ = AliasManager.aliases # lazy-load aliases
+    original_aliases: dict = dict(AliasManager._aliases)
+    mocker.patch.object(AliasManager, "save_aliases_file") # do not save to file during tests
+    yield # run test
+    AliasManager._aliases = original_aliases
 
 
 @pytest.mark.order(1)
 def test_init(deletealias_handler: DeletealiasHandler):
     assert deletealias_handler is not None
+
+
+def test_should_delete_existing_alias(deletealias_handler: DeletealiasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    AliasManager._aliases["todelete"] = AliasTemplate(
+        identifier="todelete",
+        raw="todelete | remote",
+        replacement_text="remote",
+    )
+
+    result: CommandHandlerResult = handle_call(deletealias_handler, active_date=date, arguments=["todelete"])
+
+    assert "todelete" not in AliasManager.aliases
+    assert result.error is None
+
+
+def test_should_output_message_when_alias_not_found(deletealias_handler: DeletealiasHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(deletealias_handler, active_date=date, arguments=["nonexistent"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_no_arguments(deletealias_handler: DeletealiasHandler):
+    result: CommandHandlerResult = handle_call(deletealias_handler)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(deletealias_handler: DeletealiasHandler):
+    result: CommandHandlerResult = handle_call(deletealias_handler, arguments=["alias1", "alias2"])
+
+    assert result.error is not None

--- a/tests/commands/test_deletemacro.py
+++ b/tests/commands/test_deletemacro.py
@@ -1,8 +1,59 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.deletemacro import DeletemacroHandler
+from work_tracker.command.macro_manager import MacroManager, MacroTemplate
+from work_tracker.common import Date
+
+
+@pytest.fixture(autouse=True)
+def isolate_macro_state(mocker: MockerFixture):
+    _ = MacroManager.macros # lazy-load macros
+    original_macros: dict = dict(MacroManager._macros)
+    mocker.patch.object(MacroManager, "save_macros_file") # do not save to file during tests
+    yield # run test
+    MacroManager._macros = original_macros
 
 
 @pytest.mark.order(1)
 def test_init(deletemacro_handler: DeletemacroHandler):
     assert deletemacro_handler is not None
+
+
+def test_should_delete_existing_macro(deletemacro_handler: DeletemacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["todelete"] = MacroTemplate(
+        identifier="todelete",
+        raw="todelete | remote",
+        command_text="remote",
+        arguments=[],
+        default_argument_values=[],
+    )
+
+    result: CommandHandlerResult = handle_call(deletemacro_handler, active_date=date, arguments=["todelete"])
+
+    assert "todelete" not in MacroManager.macros
+    assert result.error is None
+
+
+def test_should_output_message_when_macro_not_found(deletemacro_handler: DeletemacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(deletemacro_handler, active_date=date, arguments=["nonexistent"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_no_arguments(deletemacro_handler: DeletemacroHandler):
+    result: CommandHandlerResult = handle_call(deletemacro_handler)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(deletemacro_handler: DeletemacroHandler):
+    result: CommandHandlerResult = handle_call(deletemacro_handler, arguments=["macro1", "macro2"])
+
+    assert result.error is not None

--- a/tests/commands/test_deletemacro.py
+++ b/tests/commands/test_deletemacro.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.deletemacro import DeletemacroHandler
+
+
+@pytest.mark.order(1)
+def test_init(deletemacro_handler: DeletemacroHandler):
+    assert deletemacro_handler is not None

--- a/tests/commands/test_done.py
+++ b/tests/commands/test_done.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.done import DoneHandler
+
+
+@pytest.mark.order(1)
+def test_init(done_handler: DoneHandler):
+    assert done_handler is not None

--- a/tests/commands/test_done.py
+++ b/tests/commands/test_done.py
@@ -1,8 +1,74 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.done import DoneHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(done_handler: DoneHandler):
     assert done_handler is not None
+
+
+def test_should_set_minutes_at_work_to_target_for_active_day(done_handler: DoneHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    done_handler.data.day[date].target_minutes = 480
+    done_handler.data.day[date].minutes_at_work = 0
+
+    result: CommandHandlerResult = handle_call(done_handler, active_date=date)
+
+    assert done_handler.data.day[date].minutes_at_work == 480
+    assert result.error is None
+
+
+def test_should_set_minutes_at_work_to_target_for_active_month(done_handler: DoneHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        done_handler.data.day[day].target_minutes = 480
+        done_handler.data.day[day].minutes_at_work = 0
+
+    result: CommandHandlerResult = handle_call(done_handler, active_date=month)
+
+    for day in month.days_in_a_month():
+        assert done_handler.data.day[day].minutes_at_work == done_handler.data.day[day].target_minutes
+    assert result.error is None
+
+
+def test_should_set_minutes_at_work_to_target_for_given_days(done_handler: DoneHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        done_handler.data.day[date].target_minutes = 480
+        done_handler.data.day[date].minutes_at_work = 0
+
+    result: CommandHandlerResult = handle_call(done_handler, dates=dates)
+
+    for date in dates:
+        assert done_handler.data.day[date].minutes_at_work == 480
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_minutes_at_work_to_target_for_given_months(done_handler: DoneHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            done_handler.data.day[day].target_minutes = 480
+            done_handler.data.day[day].minutes_at_work = 0
+
+    result: CommandHandlerResult = handle_call(done_handler, dates=months)
+
+    for month in months:
+        for day in month.days_in_a_month():
+            assert done_handler.data.day[day].minutes_at_work == done_handler.data.day[day].target_minutes
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(done_handler: DoneHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(done_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_end.py
+++ b/tests/commands/test_end.py
@@ -1,8 +1,107 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.end import EndHandler
+from work_tracker.command.common import TimeArgument, TimeArgumentType
+from work_tracker.common import Date, Mode, Time
 
 
 @pytest.mark.order(1)
 def test_init(end_handler: EndHandler):
     assert end_handler is not None
+
+
+def test_should_set_work_end_to_given_time_for_active_day(end_handler: EndHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=17 * 60, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(end_handler, active_date=date, arguments=[time_arg])
+
+    assert end_handler.data.day[date].work_end is not None
+    assert end_handler.data.day[date].work_end.minutes_since_midnight == 17 * 60
+    assert result.error is None
+
+
+def test_should_set_work_end_to_now_when_no_time_argument_given(end_handler: EndHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(end_handler, active_date=date)
+
+    assert end_handler.data.day[date].work_end is not None
+    assert result.error is None
+
+
+def test_should_calculate_minutes_at_work_when_start_is_set(end_handler: EndHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    start_minutes: int = 8 * 60
+    end_minutes: int = 16 * 60
+    end_handler.data.day[date].work_start = Time(minutes_since_midnight=start_minutes)
+    time_arg: TimeArgument = TimeArgument(minutes=end_minutes, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(end_handler, active_date=date, arguments=[time_arg])
+
+    assert end_handler.data.day[date].minutes_at_work == end_minutes - start_minutes
+    assert result.error is None
+
+
+def test_should_reset_work_start_and_set_zero_minutes_when_end_before_start(end_handler: EndHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    end_handler.data.day[date].work_start = Time(minutes_since_midnight=10 * 60)
+    time_arg: TimeArgument = TimeArgument(minutes=8 * 60, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(end_handler, active_date=date, arguments=[time_arg])
+
+    assert end_handler.data.day[date].work_start.minutes_since_midnight == 8 * 60
+    assert end_handler.data.day[date].minutes_at_work == 0
+    assert result.error is None
+
+
+def test_should_set_work_end_for_given_days_with_time(end_handler: EndHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    time_arg: TimeArgument = TimeArgument(minutes=18 * 60, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(end_handler, dates=dates, arguments=[time_arg])
+
+    for date in dates:
+        assert end_handler.data.day[date].work_end is not None
+        assert end_handler.data.day[date].work_end.minutes_since_midnight == 18 * 60
+    assert result.error is None
+
+
+def test_should_set_work_end_for_given_days_without_time(end_handler: EndHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+
+    result: CommandHandlerResult = handle_call(end_handler, dates=dates)
+
+    for date in dates:
+        assert end_handler.data.day[date].work_end is not None
+    assert result.error is None
+
+
+def test_should_return_error_when_in_month_mode(end_handler: EndHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(end_handler, active_date=month, mode=Mode.Month)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(end_handler: EndHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=17 * 60, type=TimeArgumentType.Overwrite)
+    arguments: list[Any] = [time_arg, time_arg]
+
+    result: CommandHandlerResult = handle_call(end_handler, active_date=date, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date(end_handler: EndHandler, random_date: Date):
+    month_date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(end_handler, dates=[month_date])
+
+    assert result.error is not None

--- a/tests/commands/test_end.py
+++ b/tests/commands/test_end.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.end import EndHandler
+
+
+@pytest.mark.order(1)
+def test_init(end_handler: EndHandler):
+    assert end_handler is not None

--- a/tests/commands/test_exit.py
+++ b/tests/commands/test_exit.py
@@ -1,0 +1,33 @@
+import pytest
+
+from tests.conftest import handle_call
+from work_tracker.command.commands.exit import ExitHandler
+from work_tracker.common import Date, Mode
+
+
+@pytest.mark.order(1)
+def test_init(exit_handler: ExitHandler):
+    assert exit_handler is not None
+
+
+def test_should_exit_app_in_today_mode(exit_handler: ExitHandler, mocker):
+    mock_exit = mocker.patch("sys.exit")
+    
+    _ = handle_call(exit_handler, mode=Mode.Today)
+
+    mock_exit.assert_called_once()
+
+
+def test_should_change_to_today_if_not_in_today_mode(exit_handler: ExitHandler, random_date: Date, mocker):
+    mock_exit = mocker.patch("sys.exit")
+    date: Date = random_date.to_day_date()
+
+    # TODO: add this check in random_date ?
+    # if date == Date.today():
+    #     date = date.add_days(1)
+        
+    result = handle_call(exit_handler, active_date=date, mode=Mode.Day)
+
+    mock_exit.assert_not_called()
+    assert result.change_active_date == Date.today()
+    assert result.error is None

--- a/tests/commands/test_exit.py
+++ b/tests/commands/test_exit.py
@@ -12,7 +12,8 @@ def test_init(exit_handler: ExitHandler):
 
 def test_should_exit_app_in_today_mode(exit_handler: ExitHandler, mocker):
     mock_exit = mocker.patch("sys.exit")
-    
+    mocker.patch("work_tracker.command.commands.exit.CheckpointManager.save")
+
     _ = handle_call(exit_handler, mode=Mode.Today)
 
     mock_exit.assert_called_once()
@@ -21,10 +22,6 @@ def test_should_exit_app_in_today_mode(exit_handler: ExitHandler, mocker):
 def test_should_change_to_today_if_not_in_today_mode(exit_handler: ExitHandler, random_date: Date, mocker):
     mock_exit = mocker.patch("sys.exit")
     date: Date = random_date.to_day_date()
-
-    # TODO: add this check in random_date ?
-    # if date == Date.today():
-    #     date = date.add_days(1)
         
     result = handle_call(exit_handler, active_date=date, mode=Mode.Day)
 

--- a/tests/commands/test_fte.py
+++ b/tests/commands/test_fte.py
@@ -2,7 +2,7 @@ from fractions import Fraction
 
 import pytest
 
-from tests.conftest import handle_call, mock_io, TestInputOutput
+from tests.conftest import handle_call, TestInputOutput
 from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.fte import FteHandler
 from work_tracker.common import Date, Mode

--- a/tests/commands/test_help.py
+++ b/tests/commands/test_help.py
@@ -1,8 +1,56 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.help import HelpHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(help_handler: HelpHandler):
     assert help_handler is not None
+
+
+def test_should_output_command_list_when_no_arguments_given(help_handler: HelpHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(help_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_help_for_specific_command(help_handler: HelpHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(help_handler, active_date=date, arguments=["status"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_for_unknown_command_name(help_handler: HelpHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(help_handler, active_date=date, arguments=["nonexistentcommand"])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(help_handler: HelpHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    arguments: list[Any] = ["status", "extra"]
+
+    result: CommandHandlerResult = handle_call(help_handler, active_date=date, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(help_handler: HelpHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(help_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_help.py
+++ b/tests/commands/test_help.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.help import HelpHandler
+
+
+@pytest.mark.order(1)
+def test_init(help_handler: HelpHandler):
+    assert help_handler is not None

--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.history import HistoryHandler
+
+
+@pytest.mark.order(1)
+def test_init(history_handler: HistoryHandler):
+    assert history_handler is not None

--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -1,8 +1,67 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.command.command_history import CommandHistoryEntry
 from work_tracker.command.commands.history import HistoryHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(history_handler: HistoryHandler):
     assert history_handler is not None
+
+
+def test_should_output_state_history(history_handler: HistoryHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+        CommandHistoryEntry(state_key="key2", command="done"),
+    ]
+
+    result: CommandHandlerResult = handle_call(history_handler, active_date=random_date, states=states, current_state_index=2)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_history_containing_command_names(history_handler: HistoryHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(history_handler, active_date=random_date, states=states, current_state_index=1)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "remote" in output
+    assert "office" in output
+    assert result.error is None
+
+
+def test_should_output_history_with_single_state(history_handler: HistoryHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="done"),
+    ]
+
+    result: CommandHandlerResult = handle_call(history_handler, active_date=random_date, states=states, current_state_index=0)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(history_handler: HistoryHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(history_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(history_handler: HistoryHandler, random_date: Date):
+    result: CommandHandlerResult = handle_call(history_handler, dates=[random_date.to_day_date()])
+
+    assert result.error is not None

--- a/tests/commands/test_holiday.py
+++ b/tests/commands/test_holiday.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.holiday import HolidayHandler
+
+
+@pytest.mark.order(1)
+def test_init(holiday_handler: HolidayHandler):
+    assert holiday_handler is not None

--- a/tests/commands/test_holiday.py
+++ b/tests/commands/test_holiday.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import handle_call
 from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.holiday import HolidayHandler
-from work_tracker.common import DayType, Date, DayType, Mode
+from work_tracker.common import Date, DayType, Mode
 
 
 @pytest.mark.order(1)
@@ -56,8 +58,9 @@ def test_should_not_update_month_target_if_target_was_changed(holiday_handler: H
     assert result.error is None
     assert holiday_handler.data.month[month_date].target_minutes == target_before
 
+
 def test_should_return_error_on_invalid_argument_count(holiday_handler: HolidayHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(holiday_handler, arguments=arguments)
 

--- a/tests/commands/test_holiday.py
+++ b/tests/commands/test_holiday.py
@@ -35,7 +35,6 @@ def test_should_set_to_holiday_given_days(holiday_handler: HolidayHandler, rando
     assert result.error is None
 
 
-
 @pytest.mark.parametrize("random_date", [{"must_be_workday": True}], indirect=True)
 def test_should_update_month_target_if_target_was_unchanged(holiday_handler: HolidayHandler, random_date: Date):
     month_date: Date = random_date.to_month_date()
@@ -44,7 +43,7 @@ def test_should_update_month_target_if_target_was_unchanged(holiday_handler: Hol
     result: CommandHandlerResult = handle_call(holiday_handler, active_date=random_date)
 
     assert result.error is None
-    assert holiday_handler.data.month[month_date].target_minutes != target_before
+    assert holiday_handler.data.month[month_date].target_minutes < target_before
 
 
 @pytest.mark.parametrize("random_date", [{"must_be_workday": True}], indirect=True)

--- a/tests/commands/test_holiday.py
+++ b/tests/commands/test_holiday.py
@@ -1,8 +1,81 @@
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.holiday import HolidayHandler
+from work_tracker.common import DayType, Date, DayType, Mode
 
 
 @pytest.mark.order(1)
 def test_init(holiday_handler: HolidayHandler):
     assert holiday_handler is not None
+
+
+def test_should_set_to_holiday_active_day(holiday_handler: HolidayHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    holiday_handler.data.day[date].day_type = DayType.WORKDAY
+
+    result: CommandHandlerResult = handle_call(holiday_handler, active_date=date)
+
+    assert holiday_handler.data.day[date].day_type == DayType.HOLIDAY
+    assert result.error is None
+
+
+def test_should_set_to_holiday_given_days(holiday_handler: HolidayHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        holiday_handler.data.day[date].day_type = DayType.WORKDAY
+
+    result: CommandHandlerResult = handle_call(holiday_handler, dates=dates)
+
+    for date in dates:
+        assert holiday_handler.data.day[date].day_type == DayType.HOLIDAY
+    assert result.error is None
+
+
+
+@pytest.mark.parametrize("random_date", [{"must_be_workday": True}], indirect=True)
+def test_should_update_month_target_if_target_was_unchanged(holiday_handler: HolidayHandler, random_date: Date):
+    month_date: Date = random_date.to_month_date()
+    target_before: int = holiday_handler.data.month[month_date].target_minutes
+
+    result: CommandHandlerResult = handle_call(holiday_handler, active_date=random_date)
+
+    assert result.error is None
+    assert holiday_handler.data.month[month_date].target_minutes != target_before
+
+
+@pytest.mark.parametrize("random_date", [{"must_be_workday": True}], indirect=True)
+def test_should_not_update_month_target_if_target_was_changed(holiday_handler: HolidayHandler, random_date: Date):
+    month_date: Date = random_date.to_month_date()
+    holiday_handler.data.month[month_date].target_minutes += 1
+    target_before: int = holiday_handler.data.month[month_date].target_minutes
+
+    result: CommandHandlerResult = handle_call(holiday_handler, active_date=random_date)
+
+    assert result.error is None
+    assert holiday_handler.data.month[month_date].target_minutes == target_before
+
+def test_should_return_error_on_invalid_argument_count(holiday_handler: HolidayHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(holiday_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_when_used_in_month_mode(holiday_handler: HolidayHandler, random_date: Date):
+    mode: Mode = Mode.Month
+    active_date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(holiday_handler, mode=mode, active_date=active_date)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date(holiday_handler: HolidayHandler, random_date: Date):
+    date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(holiday_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_info.py
+++ b/tests/commands/test_info.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.info import InfoHandler
+
+
+@pytest.mark.order(1)
+def test_init(info_handler: InfoHandler):
+    assert info_handler is not None

--- a/tests/commands/test_info.py
+++ b/tests/commands/test_info.py
@@ -1,8 +1,84 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.info import InfoHandler
+from work_tracker.common import Date, AttendanceType, WorkLocation
 
 
 @pytest.mark.order(1)
 def test_init(info_handler: InfoHandler):
     assert info_handler is not None
+
+
+def test_should_output_info_for_active_day(info_handler: InfoHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(info_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_info_for_active_month(info_handler: InfoHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(info_handler, active_date=month)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_info_for_given_days(info_handler: InfoHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+
+    result: CommandHandlerResult = handle_call(info_handler, dates=dates)
+
+    for _ in dates:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_output_info_for_given_months(info_handler: InfoHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+
+    result: CommandHandlerResult = handle_call(info_handler, dates=months)
+
+    for _ in months:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_attendance_type_in_day_info(info_handler: InfoHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    info_handler.data.day[date].attendance_type = AttendanceType.ABSENCE
+
+    result: CommandHandlerResult = handle_call(info_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "absence" in output
+    assert result.error is None
+
+
+def test_should_output_work_location_in_day_info(info_handler: InfoHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    info_handler.data.day[date].work_location = WorkLocation.REMOTE
+
+    result: CommandHandlerResult = handle_call(info_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "remote" in output
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(info_handler: InfoHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(info_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_key.py
+++ b/tests/commands/test_key.py
@@ -1,8 +1,42 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, sample_data
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.key import KeyHandler
+from work_tracker.command.common import KeyManager
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(key_handler: KeyHandler):
     assert key_handler is not None
+
+
+def test_should_import_data_from_encoded_key(key_handler: KeyHandler, random_date: Date):
+    source_data = sample_data()
+    date: Date = random_date.to_day_date()
+    source_data.day[date].minutes_at_work = 300
+    encoded_key: str = KeyManager.encode(source_data)
+
+    result: CommandHandlerResult = handle_call(key_handler, arguments=[encoded_key])
+
+    assert key_handler.data.day[date].minutes_at_work == 300
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_date_count(key_handler: KeyHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(key_handler, dates=[date])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(key_handler: KeyHandler):
+    arguments: list[Any] = ["value", "extra"]
+
+    result: CommandHandlerResult = handle_call(key_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_key.py
+++ b/tests/commands/test_key.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.key import KeyHandler
+
+
+@pytest.mark.order(1)
+def test_init(key_handler: KeyHandler):
+    assert key_handler is not None

--- a/tests/commands/test_keyword.py
+++ b/tests/commands/test_keyword.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import TestInputOutput, handle_call
@@ -18,7 +20,7 @@ def test_should_output_keyword_list(keyword_handler: KeywordHandler):
 
 
 def test_should_return_error_on_invalid_argument_count(keyword_handler: KeywordHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(keyword_handler, arguments=arguments)
 

--- a/tests/commands/test_keyword.py
+++ b/tests/commands/test_keyword.py
@@ -1,8 +1,25 @@
 import pytest
 
+from tests.conftest import TestInputOutput, handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.keyword import KeywordHandler
 
 
 @pytest.mark.order(1)
 def test_init(keyword_handler: KeywordHandler):
     assert keyword_handler is not None
+
+
+def test_should_output_keyword_list(keyword_handler: KeywordHandler):
+    result: CommandHandlerResult = handle_call(keyword_handler)
+
+    assert TestInputOutput.get_output().strip() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(keyword_handler: KeywordHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(keyword_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_keyword.py
+++ b/tests/commands/test_keyword.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.keyword import KeywordHandler
+
+
+@pytest.mark.order(1)
+def test_init(keyword_handler: KeywordHandler):
+    assert keyword_handler is not None

--- a/tests/commands/test_macro.py
+++ b/tests/commands/test_macro.py
@@ -1,8 +1,105 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.macro import MacroHandler
+from work_tracker.command.macro_manager import MacroManager, MacroTemplate
+from work_tracker.common import Date
+
+
+@pytest.fixture(autouse=True)
+def isolate_macro_state(mocker: MockerFixture):
+    _ = MacroManager.macros # lazy-load macros
+    original_macros: dict = dict(MacroManager._macros)
+    mocker.patch.object(MacroManager, "save_macros_file") # do not save to file during tests
+    yield # run test
+    MacroManager._macros = original_macros
 
 
 @pytest.mark.order(1)
 def test_init(macro_handler: MacroHandler):
     assert macro_handler is not None
+
+
+def test_should_output_macro_list(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(macro_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_specific_macro(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro | remote",
+        command_text="remote",
+        arguments=[],
+        default_argument_values=[],
+    )
+
+    result: CommandHandlerResult = handle_call(macro_handler, active_date=date, arguments=["mymacro"])
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "mymacro" in output
+    assert result.error is None
+
+
+def test_should_output_message_for_nonexistent_macro(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(macro_handler, active_date=date, arguments=["nonexistentmacro"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_create_new_macro_without_arguments(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(macro_handler, active_date=date, arguments=["mymacro", "remote"])
+
+    assert "mymacro" in MacroManager.macros
+    assert MacroManager.macros["mymacro"].command_text == "remote"
+    assert result.error is None
+
+
+def test_should_create_new_macro_with_arguments(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(
+        macro_handler, active_date=date,
+        arguments=["mymacro", "<day>", "remote"]
+    )
+
+    assert "mymacro" in MacroManager.macros
+    assert "day" in MacroManager.macros["mymacro"].arguments
+    assert result.error is None
+
+
+def test_should_update_existing_macro(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    MacroManager._macros["mymacro"] = MacroTemplate(
+        identifier="mymacro",
+        raw="mymacro | remote",
+        command_text="remote",
+        arguments=[],
+        default_argument_values=[],
+    )
+
+    result: CommandHandlerResult = handle_call(macro_handler, active_date=date, arguments=["mymacro", "office"])
+
+    assert MacroManager.macros["mymacro"].command_text == "office"
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_date_count(macro_handler: MacroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(macro_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_macro.py
+++ b/tests/commands/test_macro.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.macro import MacroHandler
+
+
+@pytest.mark.order(1)
+def test_init(macro_handler: MacroHandler):
+    assert macro_handler is not None

--- a/tests/commands/test_minutes.py
+++ b/tests/commands/test_minutes.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.minutes import MinutesHandler
+
+
+@pytest.mark.order(1)
+def test_init(minutes_handler: MinutesHandler):
+    assert minutes_handler is not None

--- a/tests/commands/test_minutes.py
+++ b/tests/commands/test_minutes.py
@@ -1,8 +1,116 @@
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.minutes import MinutesHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(minutes_handler: MinutesHandler):
     assert minutes_handler is not None
+
+
+def test_should_output_minutes_per_day_for_active_date(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    minutes_handler.data.month[date.to_month_date()].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=[10])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_output_minutes_per_day_for_given_months(minutes_handler: MinutesHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        minutes_handler.data.month[month].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(minutes_handler, dates=months, arguments=[10])
+
+    for _ in months:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_office_minutes_per_day(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    minutes_handler.data.month[date.to_month_date()].target_minutes = 9600
+    minutes_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=["office", 10])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_remote_minutes_per_day(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    minutes_handler.data.month[date.to_month_date()].target_minutes = 9600
+    minutes_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=["remote", 10])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_clean_minutes_excluding_already_filled_dates(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    minutes_handler.data.month[date.to_month_date()].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=[10, "clean"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_office_clean_minutes(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    minutes_handler.data.month[date.to_month_date()].target_minutes = 9600
+    minutes_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=["office", 10, "clean"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count_zero(minutes_handler: MinutesHandler):
+    result: CommandHandlerResult = handle_call(minutes_handler)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_nonpositive_days(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=[0])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_negative_days(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=[-5])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_location_argument(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=["invalid", 10])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_clean_argument(minutes_handler: MinutesHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(minutes_handler, active_date=date, arguments=[10, "invalid"])
+
+    assert result.error is not None

--- a/tests/commands/test_office.py
+++ b/tests/commands/test_office.py
@@ -1,8 +1,74 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.office import OfficeHandler
+from work_tracker.common import Date, DayType, WorkLocation
 
 
 @pytest.mark.order(1)
 def test_init(office_handler: OfficeHandler):
     assert office_handler is not None
+
+
+def test_should_set_to_office_active_day(office_handler: OfficeHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    office_handler.data.day[date].work_location = WorkLocation.REMOTE
+
+    result: CommandHandlerResult = handle_call(office_handler, active_date=date)
+
+    assert office_handler.data.day[date].work_location == WorkLocation.OFFICE
+    assert result.error is None
+
+
+def test_should_set_to_office_active_month_workdays(office_handler: OfficeHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        office_handler.data.day[day].work_location = WorkLocation.REMOTE
+
+    result: CommandHandlerResult = handle_call(office_handler, active_date=month)
+
+    for day in [day for day in month.days_in_a_month() if office_handler.data.day[day].day_type == DayType.WORKDAY]:
+        assert office_handler.data.day[day].work_location == WorkLocation.OFFICE
+    for day in [day for day in month.days_in_a_month() if office_handler.data.day[day].day_type != DayType.WORKDAY]:
+        assert office_handler.data.day[day].work_location != WorkLocation.OFFICE
+    assert result.error is None
+
+
+def test_should_set_to_office_given_days(office_handler: OfficeHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        office_handler.data.day[date].work_location = WorkLocation.REMOTE
+
+    result: CommandHandlerResult = handle_call(office_handler, dates=dates)
+
+    for date in dates:
+        assert office_handler.data.day[date].work_location == WorkLocation.OFFICE
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_to_office_given_months_workdays(office_handler: OfficeHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            office_handler.data.day[day].work_location = WorkLocation.REMOTE
+
+    result: CommandHandlerResult = handle_call(office_handler, dates=months)
+
+    for month in months:
+        for day in [day for day in month.days_in_a_month() if office_handler.data.day[day].day_type == DayType.WORKDAY]:
+            assert office_handler.data.day[day].work_location == WorkLocation.OFFICE
+        for day in [day for day in month.days_in_a_month() if office_handler.data.day[day].day_type != DayType.WORKDAY]:
+            assert office_handler.data.day[day].work_location != WorkLocation.OFFICE
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(office_handler: OfficeHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(office_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_office.py
+++ b/tests/commands/test_office.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.office import OfficeHandler
+
+
+@pytest.mark.order(1)
+def test_init(office_handler: OfficeHandler):
+    assert office_handler is not None

--- a/tests/commands/test_present.py
+++ b/tests/commands/test_present.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.present import PresentHandler
+
+
+@pytest.mark.order(1)
+def test_init(present_handler: PresentHandler):
+    assert present_handler is not None

--- a/tests/commands/test_present.py
+++ b/tests/commands/test_present.py
@@ -1,8 +1,72 @@
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.present import PresentHandler
+from work_tracker.common import AttendanceType, Date, DayType
 
 
 @pytest.mark.order(1)
 def test_init(present_handler: PresentHandler):
     assert present_handler is not None
+
+
+def test_should_set_to_present_active_day(present_handler: PresentHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    present_handler.data.day[date].attendance_type = AttendanceType.DAYOFF
+
+    result: CommandHandlerResult = handle_call(present_handler, active_date=date)
+
+    assert present_handler.data.day[date].attendance_type == AttendanceType.PRESENT
+    assert result.error is None
+
+
+def test_should_set_to_present_active_month_workdays(present_handler: PresentHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        present_handler.data.day[day].attendance_type = AttendanceType.DAYOFF
+
+    result: CommandHandlerResult = handle_call(present_handler, active_date=month)
+
+    for day in [day for day in month.days_in_a_month() if present_handler.data.day[day].day_type == DayType.WORKDAY]:
+        assert present_handler.data.day[day].attendance_type == AttendanceType.PRESENT
+    for day in [day for day in month.days_in_a_month() if present_handler.data.day[day].day_type != DayType.WORKDAY]:
+        assert present_handler.data.day[day].attendance_type != AttendanceType.PRESENT
+    assert result.error is None
+
+
+def test_should_set_to_present_given_days(present_handler: PresentHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        present_handler.data.day[date].attendance_type = AttendanceType.DAYOFF
+
+    result: CommandHandlerResult = handle_call(present_handler, dates=dates)
+
+    for date in dates:
+        assert present_handler.data.day[date].attendance_type == AttendanceType.PRESENT
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_to_present_given_months_workdays(present_handler: PresentHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            present_handler.data.day[day].attendance_type = AttendanceType.DAYOFF
+
+    result: CommandHandlerResult = handle_call(present_handler, dates=months)
+
+    for month in months:
+        for day in [day for day in month.days_in_a_month() if present_handler.data.day[day].day_type == DayType.WORKDAY]:
+            assert present_handler.data.day[day].attendance_type == AttendanceType.PRESENT
+        for day in [day for day in month.days_in_a_month() if present_handler.data.day[day].day_type != DayType.WORKDAY]:
+            assert present_handler.data.day[day].attendance_type != AttendanceType.PRESENT
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(present_handler: PresentHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(present_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_present.py
+++ b/tests/commands/test_present.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import handle_call
@@ -65,7 +67,7 @@ def test_should_set_to_present_given_months_workdays(present_handler: PresentHan
 
 
 def test_should_return_error_on_invalid_argument_count(present_handler: PresentHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(present_handler, arguments=arguments)
 

--- a/tests/commands/test_redo.py
+++ b/tests/commands/test_redo.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.redo import RedoHandler
+
+
+@pytest.mark.order(1)
+def test_init(redo_handler: RedoHandler):
+    assert redo_handler is not None

--- a/tests/commands/test_redo.py
+++ b/tests/commands/test_redo.py
@@ -1,8 +1,97 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.command.command_history import CommandHistoryEntry
 from work_tracker.command.commands.redo import RedoHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(redo_handler: RedoHandler):
     assert redo_handler is not None
+
+
+def test_should_redo_one_step_by_default(redo_handler: RedoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(redo_handler, active_date=random_date, states=states, current_state_index=0)
+
+    assert result.change_state_by == 1
+    assert result.error is None
+
+
+def test_should_redo_multiple_steps_with_count_argument(redo_handler: RedoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+        CommandHistoryEntry(state_key="key2", command="done"),
+    ]
+
+    result: CommandHandlerResult = handle_call(redo_handler, active_date=random_date, states=states, current_state_index=0, arguments=[2])
+
+    assert result.change_state_by == 2
+    assert result.error is None
+
+
+def test_should_clamp_redo_steps_to_available_history(redo_handler: RedoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(redo_handler, active_date=random_date, states=states, current_state_index=0, arguments=[10])
+
+    assert result.change_state_by == 1
+    assert result.error is None
+
+
+def test_should_output_message_when_already_at_last_state(redo_handler: RedoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(redo_handler, active_date=random_date, states=states, current_state_index=1)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.change_state_by is None
+    assert result.error is None
+
+
+def test_should_output_message_when_history_is_empty(redo_handler: RedoHandler, random_date: Date):
+    result: CommandHandlerResult = handle_call(redo_handler, active_date=random_date, states=[], current_state_index=0)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_zero_count(redo_handler: RedoHandler):
+    result: CommandHandlerResult = handle_call(redo_handler, arguments=[0])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_negative_count(redo_handler: RedoHandler):
+    result: CommandHandlerResult = handle_call(redo_handler, arguments=[-1])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(redo_handler: RedoHandler):
+    arguments: list[Any] = [1, 2]
+
+    result: CommandHandlerResult = handle_call(redo_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(redo_handler: RedoHandler, random_date: Date):
+    result: CommandHandlerResult = handle_call(redo_handler, dates=[random_date.to_day_date()])
+
+    assert result.error is not None

--- a/tests/commands/test_remote.py
+++ b/tests/commands/test_remote.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.remote import RemoteHandler
+
+
+@pytest.mark.order(1)
+def test_init(remote_handler: RemoteHandler):
+    assert remote_handler is not None

--- a/tests/commands/test_remote.py
+++ b/tests/commands/test_remote.py
@@ -1,8 +1,74 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.remote import RemoteHandler
+from work_tracker.common import Date, DayType, WorkLocation
 
 
 @pytest.mark.order(1)
 def test_init(remote_handler: RemoteHandler):
     assert remote_handler is not None
+
+
+def test_should_set_to_remote_active_day(remote_handler: RemoteHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    remote_handler.data.day[date].work_location = WorkLocation.OFFICE
+
+    result: CommandHandlerResult = handle_call(remote_handler, active_date=date)
+
+    assert remote_handler.data.day[date].work_location == WorkLocation.REMOTE
+    assert result.error is None
+
+
+def test_should_set_to_remote_active_month_workdays(remote_handler: RemoteHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        remote_handler.data.day[day].work_location = WorkLocation.OFFICE
+
+    result: CommandHandlerResult = handle_call(remote_handler, active_date=month)
+
+    for day in [day for day in month.days_in_a_month() if remote_handler.data.day[day].day_type == DayType.WORKDAY]:
+        assert remote_handler.data.day[day].work_location == WorkLocation.REMOTE
+    for day in [day for day in month.days_in_a_month() if remote_handler.data.day[day].day_type != DayType.WORKDAY]:
+        assert remote_handler.data.day[day].work_location != WorkLocation.REMOTE
+    assert result.error is None
+
+
+def test_should_set_to_remote_given_days(remote_handler: RemoteHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        remote_handler.data.day[date].work_location = WorkLocation.OFFICE
+
+    result: CommandHandlerResult = handle_call(remote_handler, dates=dates)
+
+    for date in dates:
+        assert remote_handler.data.day[date].work_location == WorkLocation.REMOTE
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_to_remote_given_months_workdays(remote_handler: RemoteHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            remote_handler.data.day[day].work_location = WorkLocation.OFFICE
+
+    result: CommandHandlerResult = handle_call(remote_handler, dates=months)
+
+    for month in months:
+        for day in [day for day in month.days_in_a_month() if remote_handler.data.day[day].day_type == DayType.WORKDAY]:
+            assert remote_handler.data.day[day].work_location == WorkLocation.REMOTE
+        for day in [day for day in month.days_in_a_month() if remote_handler.data.day[day].day_type != DayType.WORKDAY]:
+            assert remote_handler.data.day[day].work_location != WorkLocation.REMOTE
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(remote_handler: RemoteHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(remote_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_rollback.py
+++ b/tests/commands/test_rollback.py
@@ -1,8 +1,79 @@
 import pytest
+from pytest_mock import MockerFixture
 
+from tests.conftest import handle_call, TestInputOutput, sample_data
+from work_tracker.checkpoint_manager import CheckpointManager, CheckpointTemplate
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.rollback import RollbackHandler
+from work_tracker.common import Date, AppData
+from path import Path
+
+
+@pytest.fixture()
+def fake_checkpoint() -> CheckpointTemplate:
+    return CheckpointTemplate(
+        path=Path("."),
+        full_identifier="user.test-checkpoint__2026-03-18_11-00-00",
+        name="user.test-checkpoint",
+        date="2026-03-18_11-00-00",
+        persistent=True,
+    )
 
 
 @pytest.mark.order(1)
 def test_init(rollback_handler: RollbackHandler):
     assert rollback_handler is not None
+
+
+def test_should_load_data_from_checkpoint(
+    rollback_handler: RollbackHandler,
+    mocker: MockerFixture,
+    random_date: Date,
+    fake_checkpoint: CheckpointTemplate,
+):
+    date: Date = random_date.to_day_date()
+    source_data: AppData = sample_data()
+    source_data.day[date].minutes_at_work = 999
+    mocker.patch.object(CheckpointManager, "checkpoints", return_value=[fake_checkpoint])
+    mocker.patch("os.path.getctime", return_value=0.0)
+    mocker.patch.object(CheckpointManager, "load", return_value=source_data)
+    rollback_handler.data.day[date].minutes_at_work = 0
+
+    result: CommandHandlerResult = handle_call(rollback_handler, active_date=date, arguments=["test-checkpoint"])
+
+    assert rollback_handler.data.day[date].minutes_at_work == 999
+    assert result.error is None
+
+
+def test_should_output_message_when_checkpoint_not_found(
+    rollback_handler: RollbackHandler,
+    mocker: MockerFixture,
+    random_date: Date,
+):
+    date: Date = random_date.to_day_date()
+    mocker.patch.object(CheckpointManager, "checkpoints", return_value=[])
+
+    result: CommandHandlerResult = handle_call(rollback_handler, active_date=date, arguments=["nosuchcheckpoint"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_no_arguments(rollback_handler: RollbackHandler):
+    result: CommandHandlerResult = handle_call(rollback_handler)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(rollback_handler: RollbackHandler):
+    result: CommandHandlerResult = handle_call(rollback_handler, arguments=["value", "extra"])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(rollback_handler: RollbackHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(rollback_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_rollback.py
+++ b/tests/commands/test_rollback.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.rollback import RollbackHandler
+
+
+@pytest.mark.order(1)
+def test_init(rollback_handler: RollbackHandler):
+    assert rollback_handler is not None

--- a/tests/commands/test_rwr.py
+++ b/tests/commands/test_rwr.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.rwr import RwrHandler
+
+
+@pytest.mark.order(1)
+def test_init(rwr_handler: RwrHandler):
+    assert rwr_handler is not None

--- a/tests/commands/test_rwr.py
+++ b/tests/commands/test_rwr.py
@@ -1,8 +1,103 @@
+from fractions import Fraction
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.rwr import RwrHandler
+from work_tracker.common import Date, Mode
 
 
 @pytest.mark.order(1)
 def test_init(rwr_handler: RwrHandler):
     assert rwr_handler is not None
+
+
+def test_should_output_rwr_for_active_date(rwr_handler: RwrHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    rwr_handler.data.month[date.to_month_date()].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(rwr_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert Fraction(0.4).limit_denominator().__str__() in output
+    assert result.error is None
+
+
+def test_should_output_office_only_when_rwr_is_zero(rwr_handler: RwrHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    rwr_handler.data.month[date.to_month_date()].remote_work_ratio = 0.0
+
+    result: CommandHandlerResult = handle_call(rwr_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "office only" in output
+    assert result.error is None
+
+
+def test_should_output_remote_only_when_rwr_is_one(rwr_handler: RwrHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    rwr_handler.data.month[date.to_month_date()].remote_work_ratio = 1.0
+
+    result: CommandHandlerResult = handle_call(rwr_handler, active_date=date)
+
+    output: str = TestInputOutput.get_output()
+    assert output is not None
+    assert "remote only" in output
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_output_rwr_for_given_months(rwr_handler: RwrHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        rwr_handler.data.month[month].remote_work_ratio = 0.5
+
+    result: CommandHandlerResult = handle_call(rwr_handler, dates=months)
+
+    for _ in months:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_change_rwr_for_active_date_in_today_mode(rwr_handler: RwrHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    new_rwr: float = 0.6
+
+    result: CommandHandlerResult = handle_call(rwr_handler, active_date=date, mode=Mode.Today, arguments=[new_rwr])
+
+    assert rwr_handler.data.month[date.to_month_date()].remote_work_ratio == new_rwr
+    assert result.error is None
+
+
+def test_should_change_rwr_for_active_date_in_month_mode(rwr_handler: RwrHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    new_rwr: float = 0.5
+
+    result: CommandHandlerResult = handle_call(rwr_handler, active_date=month, mode=Mode.Month, arguments=[new_rwr])
+
+    assert rwr_handler.data.month[month].remote_work_ratio == new_rwr
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_change_rwr_for_given_months(rwr_handler: RwrHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    new_rwr: float = 0.3
+
+    result: CommandHandlerResult = handle_call(rwr_handler, dates=months, arguments=[new_rwr])
+
+    for month in months:
+        assert rwr_handler.data.month[month].remote_work_ratio == new_rwr
+    assert result.error is None
+
+
+def test_should_return_error_on_too_many_arguments(rwr_handler: RwrHandler):
+    arguments: list[Any] = [0.4, 0.5]
+
+    result: CommandHandlerResult = handle_call(rwr_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -1,8 +1,107 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.start import StartHandler
+from work_tracker.command.common import TimeArgument, TimeArgumentType
+from work_tracker.common import Date, Mode, Time
 
 
 @pytest.mark.order(1)
 def test_init(start_handler: StartHandler):
     assert start_handler is not None
+
+
+def test_should_set_work_start_to_given_time_for_active_day(start_handler: StartHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=9 * 60, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(start_handler, active_date=date, arguments=[time_arg])
+
+    assert start_handler.data.day[date].work_start is not None
+    assert start_handler.data.day[date].work_start.minutes_since_midnight == 9 * 60
+    assert result.error is None
+
+
+def test_should_set_work_start_to_now_when_no_time_argument_given(start_handler: StartHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(start_handler, active_date=date)
+
+    assert start_handler.data.day[date].work_start is not None
+    assert result.error is None
+
+
+def test_should_calculate_minutes_at_work_when_end_is_set(start_handler: StartHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    start_minutes: int = 8 * 60
+    end_minutes: int = 16 * 60
+    start_handler.data.day[date].work_end = Time(minutes_since_midnight=end_minutes)
+    time_arg: TimeArgument = TimeArgument(minutes=start_minutes, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(start_handler, active_date=date, arguments=[time_arg])
+
+    assert start_handler.data.day[date].minutes_at_work == end_minutes - start_minutes
+    assert result.error is None
+
+
+def test_should_reset_work_start_and_set_zero_minutes_when_start_after_end(start_handler: StartHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    start_handler.data.day[date].work_end = Time(minutes_since_midnight=8 * 60)
+    time_arg: TimeArgument = TimeArgument(minutes=10 * 60, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(start_handler, active_date=date, arguments=[time_arg])
+
+    assert start_handler.data.day[date].work_end.minutes_since_midnight == 10 * 60
+    assert start_handler.data.day[date].minutes_at_work == 0
+    assert result.error is None
+
+
+def test_should_set_work_start_for_given_days_with_time(start_handler: StartHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    time_arg: TimeArgument = TimeArgument(minutes=9 * 60, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(start_handler, dates=dates, arguments=[time_arg])
+
+    for date in dates:
+        assert start_handler.data.day[date].work_start is not None
+        assert start_handler.data.day[date].work_start.minutes_since_midnight == 9 * 60
+    assert result.error is None
+
+
+def test_should_set_work_start_for_given_days_without_time(start_handler: StartHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+
+    result: CommandHandlerResult = handle_call(start_handler, dates=dates)
+
+    for date in dates:
+        assert start_handler.data.day[date].work_start is not None
+    assert result.error is None
+
+
+def test_should_return_error_when_in_month_mode(start_handler: StartHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(start_handler, active_date=month, mode=Mode.Month)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(start_handler: StartHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=9 * 60, type=TimeArgumentType.Overwrite)
+    arguments: list[Any] = [time_arg, time_arg]
+
+    result: CommandHandlerResult = handle_call(start_handler, active_date=date, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date(start_handler: StartHandler, random_date: Date):
+    month_date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(start_handler, dates=[month_date])
+
+    assert result.error is not None

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.start import StartHandler
+
+
+@pytest.mark.order(1)
+def test_init(start_handler: StartHandler):
+    assert start_handler is not None

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -1,8 +1,70 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.status import StatusHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(status_handler: StatusHandler):
     assert status_handler is not None
+
+
+def test_should_output_status_for_active_day(status_handler: StatusHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    status_handler.data.day[date].minutes_at_work = 240
+    status_handler.data.day[date].target_minutes = 480
+
+    result: CommandHandlerResult = handle_call(status_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_status_for_active_month(status_handler: StatusHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    status_handler.data.month[month].target_minutes = 9600
+    status_handler.data.month[month].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(status_handler, active_date=month)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_status_for_given_days(status_handler: StatusHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        status_handler.data.day[date].minutes_at_work = 120
+        status_handler.data.day[date].target_minutes = 480
+
+    result: CommandHandlerResult = handle_call(status_handler, dates=dates)
+
+    for _ in dates:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_output_status_for_given_months(status_handler: StatusHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        status_handler.data.month[month].target_minutes = 9600
+        status_handler.data.month[month].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(status_handler, dates=months)
+
+    for _ in months:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(status_handler: StatusHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(status_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.status import StatusHandler
+
+
+@pytest.mark.order(1)
+def test_init(status_handler: StatusHandler):
+    assert status_handler is not None

--- a/tests/commands/test_target.py
+++ b/tests/commands/test_target.py
@@ -1,8 +1,138 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.target import TargetHandler
+from work_tracker.command.common import TimeArgument, TimeArgumentType
+from work_tracker.common import Date, Mode
 
 
 @pytest.mark.order(1)
 def test_init(target_handler: TargetHandler):
     assert target_handler is not None
+
+
+def test_should_output_day_target_for_active_day(target_handler: TargetHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    target_handler.data.day[date].target_minutes = 480
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=date)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_month_target_for_active_month(target_handler: TargetHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    target_handler.data.month[month].target_minutes = 9600
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=month)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_office_target_for_active_month(target_handler: TargetHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    target_handler.data.month[month].target_minutes = 9600
+    target_handler.data.month[month].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=month, mode=Mode.Month, arguments=["office"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_output_remote_target_for_active_month(target_handler: TargetHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    target_handler.data.month[month].target_minutes = 9600
+    target_handler.data.month[month].remote_work_ratio = 0.4
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=month, mode=Mode.Month, arguments=["remote"])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_change_day_target_for_active_day(target_handler: TargetHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    time_arg: TimeArgument = TimeArgument(minutes=360, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=date, arguments=[time_arg])
+
+    assert target_handler.data.day[date].target_minutes == 360
+    assert result.error is None
+
+
+def test_should_change_month_target_for_active_month(target_handler: TargetHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    time_arg: TimeArgument = TimeArgument(minutes=9000, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=month, arguments=[time_arg])
+
+    assert target_handler.data.month[month].target_minutes == 9000
+    assert result.error is None
+
+
+def test_should_output_day_target_for_given_days(target_handler: TargetHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        target_handler.data.day[date].target_minutes = 480
+
+    result: CommandHandlerResult = handle_call(target_handler, dates=dates)
+
+    for _ in dates:
+        assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_change_day_target_for_given_days(target_handler: TargetHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    time_arg: TimeArgument = TimeArgument(minutes=300, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(target_handler, dates=dates, arguments=[time_arg])
+
+    for date in dates:
+        assert target_handler.data.day[date].target_minutes == 300
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_change_month_target_for_given_months(target_handler: TargetHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    time_arg: TimeArgument = TimeArgument(minutes=8000, type=TimeArgumentType.Overwrite)
+
+    result: CommandHandlerResult = handle_call(target_handler, dates=months, arguments=[time_arg])
+
+    for month in months:
+        assert target_handler.data.month[month].target_minutes == 8000
+    assert result.error is None
+
+
+def test_should_set_day_target_to_current_minutes_at_work(target_handler: TargetHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    target_handler.data.day[date].minutes_at_work = 270
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=date, arguments=["current"])
+
+    assert target_handler.data.day[date].target_minutes == 270
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(target_handler: TargetHandler):
+    time_arg: TimeArgument = TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)
+    arguments: list[Any] = [time_arg, time_arg]
+
+    result: CommandHandlerResult = handle_call(target_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_argument_value(target_handler: TargetHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(target_handler, active_date=date, mode=Mode.Month, arguments=["badvalue"])
+
+    assert result.error is not None

--- a/tests/commands/test_target.py
+++ b/tests/commands/test_target.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.target import TargetHandler
+
+
+@pytest.mark.order(1)
+def test_init(target_handler: TargetHandler):
+    assert target_handler is not None

--- a/tests/commands/test_tutorial.py
+++ b/tests/commands/test_tutorial.py
@@ -1,8 +1,64 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.tutorial import TutorialHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(tutorial_handler: TutorialHandler):
     assert tutorial_handler is not None
+
+
+def test_should_display_first_page_as_argument(tutorial_handler: TutorialHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(tutorial_handler, active_date=date, arguments=[1])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_display_second_page_as_argument(tutorial_handler: TutorialHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(tutorial_handler, active_date=date, arguments=[2])
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_zero_page_argument(tutorial_handler: TutorialHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(tutorial_handler, active_date=date, arguments=[0])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_page_out_of_range(tutorial_handler: TutorialHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    out_of_range_page: int = len(tutorial_handler.pages) + 1
+
+    result: CommandHandlerResult = handle_call(tutorial_handler, active_date=date, arguments=[out_of_range_page])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(tutorial_handler: TutorialHandler):
+    arguments: list[Any] = [1, 2]
+
+    result: CommandHandlerResult = handle_call(tutorial_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(tutorial_handler: TutorialHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+
+    result: CommandHandlerResult = handle_call(tutorial_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_tutorial.py
+++ b/tests/commands/test_tutorial.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.tutorial import TutorialHandler
+
+
+@pytest.mark.order(1)
+def test_init(tutorial_handler: TutorialHandler):
+    assert tutorial_handler is not None

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -1,8 +1,97 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call, TestInputOutput
+from work_tracker.command.command_handler import CommandHandlerResult
+from work_tracker.command.command_history import CommandHistoryEntry
 from work_tracker.command.commands.undo import UndoHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(undo_handler: UndoHandler):
     assert undo_handler is not None
+
+
+def test_should_undo_one_step_by_default(undo_handler: UndoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(undo_handler, active_date=random_date, states=states, current_state_index=1)
+
+    assert result.change_state_by == -1
+    assert result.error is None
+
+
+def test_should_undo_multiple_steps_with_count_argument(undo_handler: UndoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+        CommandHistoryEntry(state_key="key2", command="done"),
+    ]
+
+    result: CommandHandlerResult = handle_call(undo_handler, active_date=random_date, states=states, current_state_index=2, arguments=[2])
+
+    assert result.change_state_by == -2
+    assert result.error is None
+
+
+def test_should_clamp_undo_steps_to_available_history(undo_handler: UndoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(undo_handler, active_date=random_date, states=states, current_state_index=1, arguments=[10])
+
+    assert result.change_state_by == -1
+    assert result.error is None
+
+
+def test_should_output_message_when_already_at_first_state(undo_handler: UndoHandler, random_date: Date):
+    states: list[CommandHistoryEntry] = [
+        CommandHistoryEntry(state_key="key0", command="remote"),
+        CommandHistoryEntry(state_key="key1", command="office"),
+    ]
+
+    result: CommandHandlerResult = handle_call(undo_handler, active_date=random_date, states=states, current_state_index=0)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.change_state_by is None
+    assert result.error is None
+
+
+def test_should_output_message_when_history_is_empty(undo_handler: UndoHandler, random_date: Date):
+    result: CommandHandlerResult = handle_call(undo_handler, active_date=random_date, states=[], current_state_index=0)
+
+    assert TestInputOutput.get_output() is not None
+    assert result.error is None
+
+
+def test_should_return_error_on_zero_count(undo_handler: UndoHandler):
+    result: CommandHandlerResult = handle_call(undo_handler, arguments=[0])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_negative_count(undo_handler: UndoHandler):
+    result: CommandHandlerResult = handle_call(undo_handler, arguments=[-1])
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_too_many_arguments(undo_handler: UndoHandler):
+    arguments: list[Any] = [1, 2]
+
+    result: CommandHandlerResult = handle_call(undo_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date_count(undo_handler: UndoHandler, random_date: Date):
+    result: CommandHandlerResult = handle_call(undo_handler, dates=[random_date.to_day_date()])
+
+    assert result.error is not None

--- a/tests/commands/test_undo.py
+++ b/tests/commands/test_undo.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.undo import UndoHandler
+
+
+@pytest.mark.order(1)
+def test_init(undo_handler: UndoHandler):
+    assert undo_handler is not None

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -1,8 +1,26 @@
 import pytest
 
+from tests.conftest import TestInputOutput, handle_call
+from work_tracker import __version__
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.version import VersionHandler
 
 
 @pytest.mark.order(1)
 def test_init(version_handler: VersionHandler):
     assert version_handler is not None
+
+
+def test_should_output_correct_version_number(version_handler: VersionHandler):
+    result: CommandHandlerResult = handle_call(version_handler)
+
+    assert TestInputOutput.get_output().strip() == __version__
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(version_handler: VersionHandler):
+    arguments: list[any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(version_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.version import VersionHandler
+
+
+@pytest.mark.order(1)
+def test_init(version_handler: VersionHandler):
+    assert version_handler is not None

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from tests.conftest import TestInputOutput, handle_call
@@ -19,7 +21,7 @@ def test_should_output_correct_version_number(version_handler: VersionHandler):
 
 
 def test_should_return_error_on_invalid_argument_count(version_handler: VersionHandler):
-    arguments: list[any] = ["value"]
+    arguments: list[Any] = ["value"]
 
     result: CommandHandlerResult = handle_call(version_handler, arguments=arguments)
 

--- a/tests/commands/test_workday.py
+++ b/tests/commands/test_workday.py
@@ -1,8 +1,83 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.workday import WorkdayHandler
+from work_tracker.common import Date, DayType, Mode
 
 
 @pytest.mark.order(1)
 def test_init(workday_handler: WorkdayHandler):
     assert workday_handler is not None
+
+
+def test_should_set_to_workday_active_day(workday_handler: WorkdayHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    workday_handler.data.day[date].day_type = DayType.HOLIDAY
+
+    result: CommandHandlerResult = handle_call(workday_handler, active_date=date)
+
+    assert workday_handler.data.day[date].day_type == DayType.WORKDAY
+    assert result.error is None
+
+
+def test_should_set_to_workday_given_days(workday_handler: WorkdayHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        workday_handler.data.day[date].day_type = DayType.HOLIDAY
+
+    result: CommandHandlerResult = handle_call(workday_handler, dates=dates)
+
+    for date in dates:
+        assert workday_handler.data.day[date].day_type == DayType.WORKDAY
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_date", [{"must_be_holiday": True}], indirect=True)
+def test_should_update_month_target_if_target_was_unchanged(workday_handler: WorkdayHandler, random_date: Date):
+    month_date: Date = random_date.to_month_date()
+    target_before: int = workday_handler.data.month[month_date].target_minutes
+
+    result: CommandHandlerResult = handle_call(workday_handler, active_date=random_date)
+
+    assert result.error is None
+    assert workday_handler.data.month[month_date].target_minutes > target_before
+
+
+@pytest.mark.parametrize("random_date", [{"must_be_holiday": True}], indirect=True)
+def test_should_not_update_month_target_if_target_was_changed(workday_handler: WorkdayHandler, random_date: Date):
+    month_date: Date = random_date.to_month_date()
+    workday_handler.data.month[month_date].target_minutes += 1
+    target_before: int = workday_handler.data.month[month_date].target_minutes
+
+    result: CommandHandlerResult = handle_call(workday_handler, active_date=random_date)
+
+    assert result.error is None
+    assert workday_handler.data.month[month_date].target_minutes == target_before
+
+
+def test_should_return_error_on_invalid_argument_count(workday_handler: WorkdayHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(workday_handler, arguments=arguments)
+
+    assert result.error is not None
+
+
+def test_should_return_error_when_used_in_month_mode(workday_handler: WorkdayHandler, random_date: Date):
+    mode: Mode = Mode.Month
+    active_date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(workday_handler, mode=mode, active_date=active_date)
+
+    assert result.error is not None
+
+
+def test_should_return_error_on_invalid_date(workday_handler: WorkdayHandler, random_date: Date):
+    date: Date = random_date.to_month_date()
+
+    result: CommandHandlerResult = handle_call(workday_handler, dates=[date])
+
+    assert result.error is not None

--- a/tests/commands/test_workday.py
+++ b/tests/commands/test_workday.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.workday import WorkdayHandler
+
+
+@pytest.mark.order(1)
+def test_init(workday_handler: WorkdayHandler):
+    assert workday_handler is not None

--- a/tests/commands/test_zero.py
+++ b/tests/commands/test_zero.py
@@ -1,8 +1,70 @@
+from typing import Any
+
 import pytest
 
+from tests.conftest import handle_call
+from work_tracker.command.command_handler import CommandHandlerResult
 from work_tracker.command.commands.zero import ZeroHandler
+from work_tracker.common import Date
 
 
 @pytest.mark.order(1)
 def test_init(zero_handler: ZeroHandler):
     assert zero_handler is not None
+
+
+def test_should_set_minutes_at_work_to_zero_for_active_day(zero_handler: ZeroHandler, random_date: Date):
+    date: Date = random_date.to_day_date()
+    zero_handler.data.day[date].minutes_at_work = 480
+
+    result: CommandHandlerResult = handle_call(zero_handler, active_date=date)
+
+    assert zero_handler.data.day[date].minutes_at_work == 0
+    assert result.error is None
+
+
+def test_should_set_minutes_at_work_to_zero_for_active_month(zero_handler: ZeroHandler, random_date: Date):
+    month: Date = random_date.to_month_date()
+    for day in month.days_in_a_month():
+        zero_handler.data.day[day].minutes_at_work = 480
+
+    result: CommandHandlerResult = handle_call(zero_handler, active_date=month)
+
+    for day in month.days_in_a_month():
+        assert zero_handler.data.day[day].minutes_at_work == 0
+    assert result.error is None
+
+
+def test_should_set_minutes_at_work_to_zero_for_given_days(zero_handler: ZeroHandler, random_dates: list[Date]):
+    dates: list[Date] = [date.to_day_date() for date in random_dates]
+    for date in dates:
+        zero_handler.data.day[date].minutes_at_work = 480
+
+    result: CommandHandlerResult = handle_call(zero_handler, dates=dates)
+
+    for date in dates:
+        assert zero_handler.data.day[date].minutes_at_work == 0
+    assert result.error is None
+
+
+@pytest.mark.parametrize("random_dates", [{"unique_month_data": True}], indirect=True)
+def test_should_set_minutes_at_work_to_zero_for_given_months(zero_handler: ZeroHandler, random_dates: list[Date]):
+    months: list[Date] = [date.to_month_date() for date in random_dates]
+    for month in months:
+        for day in month.days_in_a_month():
+            zero_handler.data.day[day].minutes_at_work = 480
+
+    result: CommandHandlerResult = handle_call(zero_handler, dates=months)
+
+    for month in months:
+        for day in month.days_in_a_month():
+            assert zero_handler.data.day[day].minutes_at_work == 0
+    assert result.error is None
+
+
+def test_should_return_error_on_invalid_argument_count(zero_handler: ZeroHandler):
+    arguments: list[Any] = ["value"]
+
+    result: CommandHandlerResult = handle_call(zero_handler, arguments=arguments)
+
+    assert result.error is not None

--- a/tests/commands/test_zero.py
+++ b/tests/commands/test_zero.py
@@ -1,0 +1,8 @@
+import pytest
+
+from work_tracker.command.commands.zero import ZeroHandler
+
+
+@pytest.mark.order(1)
+def test_init(zero_handler: ZeroHandler):
+    assert zero_handler is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from work_tracker.command.command_history import CommandHistoryEntry
 from work_tracker.command.commands.clear import ClearHandler
 from work_tracker.command.commands.fte import FteHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import AppData, Date, Mode, ReadonlyAppState
+from work_tracker.common import AppData, Date, Mode, ReadonlyAppState, classproperty
 from work_tracker.text.input_output_handler import InputOutputHandler
 
 
@@ -23,8 +23,7 @@ class TestInputOutput:
     def reset_text(cls):
         cls._text = ""
 
-    @classmethod
-    @property
+    @classproperty
     def text(cls) -> str:
         return cls._text
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import datetime
 import random
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -182,8 +183,8 @@ def reset_io_buffer():
     TestInputOutput.clear()
 
 
-def get_fixture_params(request) -> dict[str, any]:
-    params: dict[str, any] = {}
+def get_fixture_params(request) -> dict[str, Any]:
+    params: dict[str, Any] = {}
     if hasattr(request, "param"):
         params = request.param if isinstance(request.param, dict) else {}
     return params
@@ -191,7 +192,7 @@ def get_fixture_params(request) -> dict[str, any]:
 
 @pytest.fixture(scope="function")
 def random_date(request) -> Date:
-    params: dict[str, any] = get_fixture_params(request)
+    params: dict[str, Any] = get_fixture_params(request)
     not_today: bool = params.get("not_today", False)
     must_be_workday: bool = params.get("must_be_workday", False)
     country_code: str = params.get("country_code", "PL")
@@ -207,7 +208,7 @@ def random_date(request) -> Date:
 
 @pytest.fixture(scope="function")
 def random_dates(request) -> list[Date]:
-    params: dict[str, any] = get_fixture_params(request)
+    params: dict[str, Any] = get_fixture_params(request)
     count: int = params.get("count", 5) # default count = 5
     unique_month_data: bool = params.get("unique_month_data", False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
+from workalendar.registry import registry
 
 from work_tracker import WorkTracker
 from work_tracker.command.command_handler import CommandHandler, CommandHandlerResult
@@ -192,12 +193,16 @@ def get_fixture_params(request) -> dict[str, any]:
 def random_date(request) -> Date:
     params: dict[str, any] = get_fixture_params(request)
     not_today: bool = params.get("not_today", False)
+    must_be_workday: bool = params.get("must_be_workday", False)
+    country_code: str = params.get("country_code", "PL")
 
     while date := generate_date():
         if not_today and date == Date.today():
             continue
+        if must_be_workday and not registry.get_calendars().get(country_code)().is_working_day(date.to_datetime()):
+            continue
         break
-    return generate_date()
+    return date
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ from pytest_mock import MockerFixture
 
 from work_tracker.command.command_handler import CommandHandler, CommandHandlerResult
 from work_tracker.command.command_history import CommandHistoryEntry
+from work_tracker.command.commands.calendar import CalendarHandler
 from work_tracker.command.commands.clear import ClearHandler
+from work_tracker.command.commands.exit import ExitHandler
 from work_tracker.command.commands.fte import FteHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import AppData, Date, Mode, ReadonlyAppState, classproperty
@@ -130,18 +132,24 @@ def handle_call(
     return result
 
 
+def get_fixture_params(request) -> dict[str, any]:
+    params: dict[str, any] = {}
+    if hasattr(request, "param"):
+        params = request.param if isinstance(request.param, dict) else {}
+    return params
+
+
 @pytest.fixture(scope="function")
-def random_date() -> Date:
+def random_date(request) -> Date:
+    params: dict[str, any] = get_fixture_params(request)
+    not_today: bool = params.get("not_today", False)
+
     return generate_date()
 
 
 @pytest.fixture(scope="function")
 def random_dates(request) -> list[Date]:
-    params: dict[str, any]
-    if not hasattr(request, "param"):
-        params = {}
-    else:
-        params = request.param if isinstance(request.param, dict) else {}
+    params: dict[str, any] = get_fixture_params(request)
     count: int = params.get("count", 5) # default count = 5
     unique_month_data: bool = params.get("unique_month_data", False)
 
@@ -165,8 +173,24 @@ def random_dates(request) -> list[Date]:
 
 
 @pytest.fixture(scope="function")
+def calendar_handler(mocker: MockerFixture) -> CalendarHandler:
+    return CalendarHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
 def clear_handler(mocker: MockerFixture) -> ClearHandler:
     return ClearHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def exit_handler(mocker: MockerFixture) -> ExitHandler:
+    return ExitHandler(
         work_data=sample_data(),
         io=mock_io(mocker)
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,17 @@ from work_tracker.command.commands.undo import UndoHandler
 from work_tracker.command.commands.version import VersionHandler
 from work_tracker.command.commands.workday import WorkdayHandler
 from work_tracker.command.commands.zero import ZeroHandler
+from work_tracker.command.commands import __date as _date_module
+from work_tracker.command.commands import __time as _time_module
+from work_tracker.command.commands import __macro as _macro_module
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import AppData, Date, Mode, ReadonlyAppState, classproperty
 from work_tracker.text.input_output_handler import InputOutputHandler
+
+
+_DateHandler = getattr(_date_module, "__DateHandler")
+_TimeHandler = getattr(_time_module, "__TimeHandler")
+_MacroHandler = getattr(_macro_module, "__MacroHandler")
 
 
 class TestInputOutput:
@@ -232,6 +240,30 @@ def random_dates(request) -> list[Date]:
         dates.append(date)
 
     return dates
+
+
+@pytest.fixture(scope="function")
+def internal_date_handler(mocker: MockerFixture):
+    return _DateHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def internal_time_handler(mocker: MockerFixture):
+    return _TimeHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def internal_macro_handler(mocker: MockerFixture):
+    return _MacroHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
 
 
 @pytest.fixture(scope="function")
@@ -520,5 +552,3 @@ def zero_handler(mocker: MockerFixture) -> ZeroHandler:
         work_data=sample_data(),
         io=mock_io(mocker)
     )
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from work_tracker import WorkTracker
 from work_tracker.command.command_handler import CommandHandler, CommandHandlerResult
 from work_tracker.command.command_history import CommandHistoryEntry
 from work_tracker.command.commands.calendar import CalendarHandler
@@ -130,6 +131,11 @@ def handle_call(
     )
 
     return result
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_test_environment():
+    WorkTracker()._create_basic_files()
 
 
 def get_fixture_params(request) -> dict[str, any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,10 @@ def random_date(request) -> Date:
     params: dict[str, any] = get_fixture_params(request)
     not_today: bool = params.get("not_today", False)
 
+    while date := generate_date():
+        if not_today and date == Date.today():
+            continue
+        break
     return generate_date()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,12 @@ class TestInputOutput:
     _output_queue: list[str] = []
 
     @classmethod
+    def clear(cls):
+        cls._text = ""
+        cls._input_queue = []
+        cls._output_queue = []
+
+    @classmethod
     def reset_text(cls):
         cls._text = ""
 
@@ -136,6 +142,11 @@ def handle_call(
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_environment():
     WorkTracker()._create_basic_files()
+
+
+@pytest.fixture(autouse=True)
+def reset_io_buffer():
+    TestInputOutput.clear()
 
 
 def get_fixture_params(request) -> dict[str, any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,12 +195,15 @@ def random_date(request) -> Date:
     params: dict[str, Any] = get_fixture_params(request)
     not_today: bool = params.get("not_today", False)
     must_be_workday: bool = params.get("must_be_workday", False)
+    must_be_holiday: bool = params.get("must_be_holiday", False)
     country_code: str = params.get("country_code", "PL")
 
     while date := generate_date():
         if not_today and date == Date.today():
             continue
         if must_be_workday and not registry.get_calendars().get(country_code)().is_working_day(date.to_datetime()):
+            continue
+        if must_be_holiday and not registry.get_calendars().get(country_code)().is_holiday(date.to_datetime()):
             continue
         break
     return date

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,42 @@ from pytest_mock import MockerFixture
 from work_tracker import WorkTracker
 from work_tracker.command.command_handler import CommandHandler, CommandHandlerResult
 from work_tracker.command.command_history import CommandHistoryEntry
+from work_tracker.command.commands.absence import AbsenceHandler
+from work_tracker.command.commands.alias import AliasHandler
 from work_tracker.command.commands.calendar import CalendarHandler
+from work_tracker.command.commands.checkpoint import CheckpointHandler
 from work_tracker.command.commands.clear import ClearHandler
+from work_tracker.command.commands.config import ConfigHandler
+from work_tracker.command.commands.dayoff import DayoffHandler
+from work_tracker.command.commands.days import DaysHandler
+from work_tracker.command.commands.deletealias import DeletealiasHandler
+from work_tracker.command.commands.deletemacro import DeletemacroHandler
+from work_tracker.command.commands.done import DoneHandler
+from work_tracker.command.commands.end import EndHandler
 from work_tracker.command.commands.exit import ExitHandler
 from work_tracker.command.commands.fte import FteHandler
+from work_tracker.command.commands.help import HelpHandler
+from work_tracker.command.commands.history import HistoryHandler
+from work_tracker.command.commands.holiday import HolidayHandler
+from work_tracker.command.commands.info import InfoHandler
+from work_tracker.command.commands.key import KeyHandler
+from work_tracker.command.commands.keyword import KeywordHandler
+from work_tracker.command.commands.macro import MacroHandler
+from work_tracker.command.commands.minutes import MinutesHandler
+from work_tracker.command.commands.office import OfficeHandler
+from work_tracker.command.commands.present import PresentHandler
+from work_tracker.command.commands.redo import RedoHandler
+from work_tracker.command.commands.remote import RemoteHandler
+from work_tracker.command.commands.rollback import RollbackHandler
+from work_tracker.command.commands.rwr import RwrHandler
+from work_tracker.command.commands.start import StartHandler
+from work_tracker.command.commands.status import StatusHandler
+from work_tracker.command.commands.target import TargetHandler
+from work_tracker.command.commands.tutorial import TutorialHandler
+from work_tracker.command.commands.undo import UndoHandler
+from work_tracker.command.commands.version import VersionHandler
+from work_tracker.command.commands.workday import WorkdayHandler
+from work_tracker.command.commands.zero import ZeroHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import AppData, Date, Mode, ReadonlyAppState, classproperty
 from work_tracker.text.input_output_handler import InputOutputHandler
@@ -194,6 +226,22 @@ def random_dates(request) -> list[Date]:
 
 
 @pytest.fixture(scope="function")
+def absence_handler(mocker: MockerFixture) -> AbsenceHandler:
+    return AbsenceHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def alias_handler(mocker: MockerFixture) -> AliasHandler:
+    return AliasHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
 def calendar_handler(mocker: MockerFixture) -> CalendarHandler:
     return CalendarHandler(
         work_data=sample_data(),
@@ -202,8 +250,72 @@ def calendar_handler(mocker: MockerFixture) -> CalendarHandler:
 
 
 @pytest.fixture(scope="function")
+def checkpoint_handler(mocker: MockerFixture) -> CheckpointHandler:
+    return CheckpointHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
 def clear_handler(mocker: MockerFixture) -> ClearHandler:
     return ClearHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def config_handler(mocker: MockerFixture) -> ConfigHandler:
+    return ConfigHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def dayoff_handler(mocker: MockerFixture) -> DayoffHandler:
+    return DayoffHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def days_handler(mocker: MockerFixture) -> DaysHandler:
+    return DaysHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def deletealias_handler(mocker: MockerFixture) -> DeletealiasHandler:
+    return DeletealiasHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def deletemacro_handler(mocker: MockerFixture) -> DeletemacroHandler:
+    return DeletemacroHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def done_handler(mocker: MockerFixture) -> DoneHandler:
+    return DoneHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def end_handler(mocker: MockerFixture) -> EndHandler:
+    return EndHandler(
         work_data=sample_data(),
         io=mock_io(mocker)
     )
@@ -220,6 +332,182 @@ def exit_handler(mocker: MockerFixture) -> ExitHandler:
 @pytest.fixture(scope="function")
 def fte_handler(mocker: MockerFixture) -> FteHandler:
     return FteHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def help_handler(mocker: MockerFixture) -> HelpHandler:
+    return HelpHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def history_handler(mocker: MockerFixture) -> HistoryHandler:
+    return HistoryHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def holiday_handler(mocker: MockerFixture) -> HolidayHandler:
+    return HolidayHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def info_handler(mocker: MockerFixture) -> InfoHandler:
+    return InfoHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def key_handler(mocker: MockerFixture) -> KeyHandler:
+    return KeyHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def keyword_handler(mocker: MockerFixture) -> KeywordHandler:
+    return KeywordHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def macro_handler(mocker: MockerFixture) -> MacroHandler:
+    return MacroHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def minutes_handler(mocker: MockerFixture) -> MinutesHandler:
+    return MinutesHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def office_handler(mocker: MockerFixture) -> OfficeHandler:
+    return OfficeHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def present_handler(mocker: MockerFixture) -> PresentHandler:
+    return PresentHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def redo_handler(mocker: MockerFixture) -> RedoHandler:
+    return RedoHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def remote_handler(mocker: MockerFixture) -> RemoteHandler:
+    return RemoteHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def rollback_handler(mocker: MockerFixture) -> RollbackHandler:
+    return RollbackHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def rwr_handler(mocker: MockerFixture) -> RwrHandler:
+    return RwrHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def start_handler(mocker: MockerFixture) -> StartHandler:
+    return StartHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def status_handler(mocker: MockerFixture) -> StatusHandler:
+    return StatusHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def target_handler(mocker: MockerFixture) -> TargetHandler:
+    return TargetHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def tutorial_handler(mocker: MockerFixture) -> TutorialHandler:
+    return TutorialHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def undo_handler(mocker: MockerFixture) -> UndoHandler:
+    return UndoHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def version_handler(mocker: MockerFixture) -> VersionHandler:
+    return VersionHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def workday_handler(mocker: MockerFixture) -> WorkdayHandler:
+    return WorkdayHandler(
+        work_data=sample_data(),
+        io=mock_io(mocker)
+    )
+
+
+@pytest.fixture(scope="function")
+def zero_handler(mocker: MockerFixture) -> ZeroHandler:
+    return ZeroHandler(
         work_data=sample_data(),
         io=mock_io(mocker)
     )

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -1,0 +1,17 @@
+import pexpect
+
+
+def test_launch():
+    work_tracker = pexpect.spawn("python -m work_tracker.main -suc")
+    # first-time prompt
+    work_tracker.expect(">>")
+    work_tracker.sendline("pl")
+    work_tracker.expect(">>")
+    work_tracker.sendline("no")
+    # successful launch, test help command
+    work_tracker.expect(">>")
+    work_tracker.sendline("help")
+    work_tracker.expect(">>")
+    work_tracker.sendline("exit")
+    work_tracker.expect_exact(pexpect.EOF)
+

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -1,0 +1,100 @@
+import pytest
+
+from tests.conftest import sample_data
+from work_tracker.command.command_parser import CommandParser
+from work_tracker.command.common import ParseResult, TimeArgument, TimeArgumentType
+from work_tracker.common import AppData, Date
+
+
+@pytest.mark.order(1)
+def test_should_correctly_parse_different_times():
+    test_cases: list[tuple[str, TimeArgument]] = [
+        ("8:00", TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)),
+        ("7h", TimeArgument(minutes=420, type=TimeArgumentType.Overwrite)),
+        # ("6 h", TimeArgument(minutes=360, type=TimeArgumentType.Overwrite)), # this case wont work because of the 'h' alias
+        ("5hours", TimeArgument(minutes=300, type=TimeArgumentType.Overwrite)),
+        ("4 hours", TimeArgument(minutes=240, type=TimeArgumentType.Overwrite)),
+        ("3hour", TimeArgument(minutes=180, type=TimeArgumentType.Overwrite)),
+        ("2 hour", TimeArgument(minutes=120, type=TimeArgumentType.Overwrite)),
+        ("300minutes", TimeArgument(minutes=300, type=TimeArgumentType.Overwrite)),
+        ("290 minutes", TimeArgument(minutes=290, type=TimeArgumentType.Overwrite)),
+        ("280minute", TimeArgument(minutes=280, type=TimeArgumentType.Overwrite)),
+        ("270 minute", TimeArgument(minutes=270, type=TimeArgumentType.Overwrite)),
+        ("260mins", TimeArgument(minutes=260, type=TimeArgumentType.Overwrite)),
+        ("250 mins", TimeArgument(minutes=250, type=TimeArgumentType.Overwrite)),
+        ("240min", TimeArgument(minutes=240, type=TimeArgumentType.Overwrite)),
+        ("230 min", TimeArgument(minutes=230, type=TimeArgumentType.Overwrite)),
+        ("220m", TimeArgument(minutes=220, type=TimeArgumentType.Overwrite)),
+        ("210 m", TimeArgument(minutes=210, type=TimeArgumentType.Overwrite)),
+    ]
+
+    for text, expected in test_cases:
+        data: AppData = sample_data()
+        for prefix in ("+", "+ ", "-", "- ", ""):
+            parse_result: ParseResult = CommandParser.parse(prefix + text, data)
+            assert parse_result.error is None
+            assert len(parse_result.queries) == 1
+            assert parse_result.queries[0].command.name == "__time"
+            assert len(parse_result.queries[0].arguments) == 1
+            assert isinstance(parse_result.queries[0].arguments[0], TimeArgument)
+            assert parse_result.queries[0].arguments[0].minutes == expected.minutes
+            if prefix.strip() == "+":
+                assert parse_result.queries[0].arguments[0].type == TimeArgumentType.Add
+            elif prefix.strip() == "-":
+                assert parse_result.queries[0].arguments[0].type == TimeArgumentType.Subtract
+            else:
+                assert parse_result.queries[0].arguments[0].type == TimeArgumentType.Overwrite
+
+
+@pytest.mark.order(1)
+def test_should_correctly_parse_different_dates():
+    test_cases: list[tuple[str, Date]] = [
+        ("22.", Date(year=None, month=None, day=22)),
+        ("01.", Date(year=None, month=None, day=1)),
+        ("2.", Date(year=None, month=None, day=2)),
+        ("03.12", Date(year=None, month=12, day=3)),
+        ("2.11", Date(year=None, month=11, day=2)),
+        ("10.10", Date(year=None, month=10, day=10)),
+        ("30.12.98", Date(year=1998, month=12, day=30)),
+        ("01.02.03", Date(year=2003, month=2, day=1)),
+        ("2.3.4", Date(year=2004, month=3, day=2)),
+        ("03.04.2005", Date(year=2005, month=4, day=3)),
+        ("4.5.2006", Date(year=2006, month=5, day=4)),
+
+        (".03.", Date(year=None, month=3, day=None)),
+        (".4.", Date(year=None, month=4, day=None)),
+        (".05.2007", Date(year=2007, month=5, day=None)),
+        (".6.08", Date(year=2008, month=6, day=None)),
+
+        ("feb", Date(year=None, month=2, day=None)),
+        ("february", Date(year=None, month=2, day=None)),
+    ]
+
+    for text, expected in test_cases:
+        data: AppData = sample_data()
+        parse_result: ParseResult = CommandParser.parse(text, data)
+        assert parse_result.error is None
+        assert len(parse_result.queries) == 1
+        assert parse_result.queries[0].command.name == "__date"
+        assert len(parse_result.queries[0].arguments) == 0
+        assert parse_result.queries[0].date_count == 1
+        assert parse_result.queries[0].dates[0] == expected
+
+
+# @pytest.mark.order(1)
+# def test_should_correctly_parse_multiple_dates():
+#     test_cases: list[tuple[str, list[Date]]] = [
+#         ("22. 23. 24.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23), Date(year=None, month=None, day=24)]),
+#         ("22. 23. 24.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23), Date(year=None, month=None, day=24)]),
+#         ("22. 23. 24.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23), Date(year=None, month=None, day=24)]),
+#     ]
+
+#     for text, expected in test_cases:
+#         data: AppData = sample_data()
+#         parse_result: ParseResult = CommandParser.parse(text, data)
+#         assert parse_result.error is None
+#         assert len(parse_result.queries) == 1
+#         assert parse_result.queries[0].command.name == "__date"
+#         assert len(parse_result.queries[0].arguments) == 0
+#         assert parse_result.queries[0].date_count == 1
+#         assert parse_result.queries[0].dates[0] == expected

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -11,7 +11,7 @@ def test_should_correctly_parse_different_times():
     test_cases: list[tuple[str, TimeArgument]] = [
         ("8:00", TimeArgument(minutes=480, type=TimeArgumentType.Overwrite)),
         ("7h", TimeArgument(minutes=420, type=TimeArgumentType.Overwrite)),
-        # ("6 h", TimeArgument(minutes=360, type=TimeArgumentType.Overwrite)), # this case wont work because of the 'h' alias
+        # ("6 h", TimeArgument(minutes=360, type=TimeArgumentType.Overwrite)), # this case will not work because of the 'h' alias
         ("5hours", TimeArgument(minutes=300, type=TimeArgumentType.Overwrite)),
         ("4 hours", TimeArgument(minutes=240, type=TimeArgumentType.Overwrite)),
         ("3hour", TimeArgument(minutes=180, type=TimeArgumentType.Overwrite)),
@@ -81,20 +81,24 @@ def test_should_correctly_parse_different_dates():
         assert parse_result.queries[0].dates[0] == expected
 
 
-# @pytest.mark.order(1)
-# def test_should_correctly_parse_multiple_dates():
-#     test_cases: list[tuple[str, list[Date]]] = [
-#         ("22. 23. 24.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23), Date(year=None, month=None, day=24)]),
-#         ("22. 23. 24.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23), Date(year=None, month=None, day=24)]),
-#         ("22. 23. 24.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23), Date(year=None, month=None, day=24)]),
-#     ]
+@pytest.mark.order(index=1, after=["test_should_correctly_parse_different_times", "test_should_correctly_parse_different_dates"])
+def test_should_correctly_parse_multiple_dates():
+    test_cases: list[tuple[str, list[Date]]] = [
+        ("22. 23.", [Date(year=None, month=None, day=22), Date(year=None, month=None, day=23)]),
+        ("18. 16. 17. 15.", [Date(year=None, month=None, day=18), Date(year=None, month=None, day=16), Date(year=None, month=None, day=17), Date(year=None, month=None, day=15)]),
+        ("30. 29. 28.", [Date(year=None, month=None, day=30), Date(year=None, month=None, day=29), Date(year=None, month=None, day=28)]),
 
-#     for text, expected in test_cases:
-#         data: AppData = sample_data()
-#         parse_result: ParseResult = CommandParser.parse(text, data)
-#         assert parse_result.error is None
-#         assert len(parse_result.queries) == 1
-#         assert parse_result.queries[0].command.name == "__date"
-#         assert len(parse_result.queries[0].arguments) == 0
-#         assert parse_result.queries[0].date_count == 1
-#         assert parse_result.queries[0].dates[0] == expected
+        ("01.02 02. .03.2024 .4.", [Date(year=None, month=2, day=1), Date(year=None, month=None, day=2), Date(year=2024, month=3, day=None), Date(year=None, month=4, day=None)]),
+        ("18. jun 06.07.99", [Date(year=None, month=None, day=18), Date(year=None, month=6, day=None), Date(year=1999, month=7, day=6)]),
+    ]
+
+    for text, expected in test_cases:
+        data: AppData = sample_data()
+        parse_result: ParseResult = CommandParser.parse(text + " 2h", data)
+        assert parse_result.error is None
+        assert len(parse_result.queries) == 1
+        assert parse_result.queries[0].command.name == "__time"
+        assert len(parse_result.queries[0].arguments) == 1
+        assert parse_result.queries[0].date_count == len(expected)
+        for index, date in enumerate(parse_result.queries[0].dates):
+            assert date == expected[index]

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,0 +1,167 @@
+from typing import Any
+
+import pytest
+
+from work_tracker.config import MainConfig
+
+
+CONFIG_V1: dict[str, Any] = {
+    "command": {
+        "calendar": {
+            "dayoff_background_color": None,
+            "dayoff_foreground_color": "brightmagenta",
+            "holiday_background_color": None,
+            "holiday_foreground_color": "brightgreen",
+            "office_background_color": None,
+            "office_foreground_color": "brightred",
+            "remote_background_color": None,
+            "remote_foreground_color": "brightblue",
+            "title_color": None,
+            "weekend_background_color": None,
+            "weekend_foreground_color": "yellow",
+        },
+        "help": {
+            "command_list_description_padding": 2,
+            "command_use_case_bullet_point_symbol": "- ",
+            "command_use_case_description_padding": 4,
+            "command_use_case_indent_size": 2,
+        },
+        "undo_history_size": 50,
+    },
+    "input": {
+        "command_chain_symbol": "&&",
+        "prefix": ">>",
+        "sub_prefix": ":",
+    },
+    "output": {
+        "frame": {
+            "padding": 1,
+            "title_footer_right_side_padding": 2,
+            "title_left_side_padding": 2,
+            "title_padding": 1,
+        },
+        "max_width": 80,
+    },
+    "version": 1,
+}
+
+
+def _migrate_v1_to_v2() -> dict[str, Any]:
+    raw: dict[str, Any] = {k: v for k, v in CONFIG_V1.items()}
+    raw["command"] = {k: v for k, v in CONFIG_V1["command"].items()}
+    raw["command"]["calendar"] = dict(CONFIG_V1["command"]["calendar"])
+    raw["command"]["help"] = dict(CONFIG_V1["command"]["help"])
+    raw["input"] = dict(CONFIG_V1["input"])
+    raw["output"] = {k: v for k, v in CONFIG_V1["output"].items()}
+    raw["output"]["frame"] = dict(CONFIG_V1["output"]["frame"])
+    MainConfig._update_config_data_to_latest_version(raw)
+    return raw
+
+
+@pytest.fixture
+def v1_to_v2() -> dict[str, Any]:
+    return _migrate_v1_to_v2()
+
+
+def test_v1_to_v2_bumps_version(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["version"] == 2
+
+
+def test_v1_to_v2_produces_valid_config(v1_to_v2: dict[str, Any]):
+    config: MainConfig = MainConfig(**v1_to_v2)
+    assert config.version == 2
+
+
+# --- input ---
+
+def test_v1_to_v2_adds_keyword_prefix(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["keyword_prefix"] == "$"
+
+
+def test_v1_to_v2_adds_history_size(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["history_size"] == 1000
+
+
+def test_v1_to_v2_adds_date_multi_start_symbol(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["date"]["multi_start_symbol"] == "("
+
+
+def test_v1_to_v2_adds_date_multi_end_symbol(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["date"]["multi_end_symbol"] == ")"
+
+
+def test_v1_to_v2_adds_date_normalize(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["date"]["normalize"] is False
+
+
+def test_v1_to_v2_adds_time_add_prefix(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["time"]["add_prefix"] == "+"
+
+
+def test_v1_to_v2_adds_time_subtract_prefix(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["time"]["subtract_prefix"] == "-"
+
+
+# --- command ---
+
+def test_v1_to_v2_adds_fte_default_value(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["fte"]["default_value"] == 1.0
+
+
+def test_v1_to_v2_adds_rwr_default_value(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["rwr"]["default_value"] == 0.4
+
+
+def test_v1_to_v2_adds_calendar_absence_foreground_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["calendar"]["absence_foreground_color"] == "brightblue"
+
+
+def test_v1_to_v2_adds_calendar_absence_background_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["calendar"]["absence_background_color"] is None
+
+
+def test_v1_to_v2_adds_calendar_office_incomplete_foreground_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["calendar"]["office_incomplete_foreground_color"] == "red"
+
+
+def test_v1_to_v2_adds_calendar_office_incomplete_background_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["calendar"]["office_incomplete_background_color"] is None
+
+
+def test_v1_to_v2_adds_calendar_remote_incomplete_foreground_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["calendar"]["remote_incomplete_foreground_color"] == "green"
+
+
+def test_v1_to_v2_adds_calendar_remote_incomplete_background_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["calendar"]["remote_incomplete_background_color"] is None
+
+
+# --- output ---
+
+def test_v1_to_v2_adds_error_color(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["output"]["error_color"] == "brightred"
+
+
+# --- preserves existing values ---
+
+def test_v1_to_v2_preserves_existing_calendar_colors(v1_to_v2: dict[str, Any]):
+    cal = v1_to_v2["command"]["calendar"]
+    assert cal["dayoff_foreground_color"] == "brightmagenta"
+    assert cal["holiday_foreground_color"] == "brightgreen"
+    assert cal["office_foreground_color"] == "brightred"
+    assert cal["remote_foreground_color"] == "brightblue"
+    assert cal["weekend_foreground_color"] == "yellow"
+
+
+def test_v1_to_v2_preserves_undo_history_size(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["command"]["undo_history_size"] == 50
+
+
+def test_v1_to_v2_preserves_output_max_width(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["output"]["max_width"] == 80
+
+
+def test_v1_to_v2_preserves_input_prefix(v1_to_v2: dict[str, Any]):
+    assert v1_to_v2["input"]["prefix"] == ">>"
+    assert v1_to_v2["input"]["sub_prefix"] == ":"
+    assert v1_to_v2["input"]["command_chain_symbol"] == "&&"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,737 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <4.0"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "convertdate"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymeeus" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/8d/540bf9cdbcd59352ecf7a1925197881465a6c24fd6171765dc11bbeed19e/convertdate-2.4.1.tar.gz", hash = "sha256:ace904a9d0230742732471748160b99d6ae881c2d0dc9a2463c7a37340c56c91", size = 52505, upload-time = "2026-02-08T00:37:53.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/53/63d707d9de41aab3c51faa4f0e9234c36ee8c63f56c90c3ae23a01976e81/convertdate-2.4.1-py3-none-any.whl", hash = "sha256:0622acf8bc600956b937e8dd7cee36ba035669b62d2db224bf130af1fc84f754", size = 48440, upload-time = "2026-02-08T00:37:52.405Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/d4/7827d9ffa34d5d4d752eec907022aa417120936282fc488306f5da08c292/coverage-7.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415", size = 219152, upload-time = "2026-02-09T12:56:11.974Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b0/d69df26607c64043292644dbb9dc54b0856fabaa2cbb1eeee3331cc9e280/coverage-7.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b", size = 219667, upload-time = "2026-02-09T12:56:13.33Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a4/c1523f7c9e47b2271dbf8c2a097e7a1f89ef0d66f5840bb59b7e8814157b/coverage-7.13.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a", size = 246425, upload-time = "2026-02-09T12:56:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/aa7ec01d1a5023c4b680ab7257f9bfde9defe8fdddfe40be096ac19e8177/coverage-7.13.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f", size = 248229, upload-time = "2026-02-09T12:56:16.31Z" },
+    { url = "https://files.pythonhosted.org/packages/35/98/85aba0aed5126d896162087ef3f0e789a225697245256fc6181b95f47207/coverage-7.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012", size = 250106, upload-time = "2026-02-09T12:56:18.024Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1db59bd67494bc162e3e4cd5fbc7edba2c7026b22f7c8ef1496d58c2b94c/coverage-7.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def", size = 252021, upload-time = "2026-02-09T12:56:19.272Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/97/72899c59c7066961de6e3daa142d459d47d104956db43e057e034f015c8a/coverage-7.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256", size = 247114, upload-time = "2026-02-09T12:56:21.051Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1f/f1885573b5970235e908da4389176936c8933e86cb316b9620aab1585fa2/coverage-7.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda", size = 248143, upload-time = "2026-02-09T12:56:22.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/cf/e80390c5b7480b722fa3e994f8202807799b85bc562aa4f1dde209fbb7be/coverage-7.13.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92", size = 246152, upload-time = "2026-02-09T12:56:23.748Z" },
+    { url = "https://files.pythonhosted.org/packages/44/bf/f89a8350d85572f95412debb0fb9bb4795b1d5b5232bd652923c759e787b/coverage-7.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c", size = 249959, upload-time = "2026-02-09T12:56:25.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6e/612a02aece8178c818df273e8d1642190c4875402ca2ba74514394b27aba/coverage-7.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58", size = 246416, upload-time = "2026-02-09T12:56:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/98/b5afc39af67c2fa6786b03c3a7091fc300947387ce8914b096db8a73d67a/coverage-7.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9", size = 247025, upload-time = "2026-02-09T12:56:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/51/30/2bba8ef0682d5bd210c38fe497e12a06c9f8d663f7025e9f5c2c31ce847d/coverage-7.13.4-cp310-cp310-win32.whl", hash = "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf", size = 221758, upload-time = "2026-02-09T12:56:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/78/13/331f94934cf6c092b8ea59ff868eb587bc8fe0893f02c55bc6c0183a192e/coverage-7.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95", size = 222693, upload-time = "2026-02-09T12:56:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ad/b59e5b451cf7172b8d1043dc0fa718f23aab379bc1521ee13d4bd9bfa960/coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053", size = 219278, upload-time = "2026-02-09T12:56:31.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/0cb7ca3de72e5f4ef2ec2fa0089beafbcaaaead1844e8b8a63d35173d77d/coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11", size = 219783, upload-time = "2026-02-09T12:56:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/63/325d8e5b11e0eaf6d0f6a44fad444ae58820929a9b0de943fa377fe73e85/coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa", size = 250200, upload-time = "2026-02-09T12:56:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/76/53/c16972708cbb79f2942922571a687c52bd109a7bd51175aeb7558dff2236/coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7", size = 252114, upload-time = "2026-02-09T12:56:35.749Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c2/7ab36d8b8cc412bec9ea2d07c83c48930eb4ba649634ba00cb7e4e0f9017/coverage-7.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00", size = 254220, upload-time = "2026-02-09T12:56:37.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/4d/cf52c9a3322c89a0e6febdfbc83bb45c0ed3c64ad14081b9503adee702e7/coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef", size = 256164, upload-time = "2026-02-09T12:56:39.016Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/eb1dd17bd6de8289df3580e967e78294f352a5df8a57ff4671ee5fc3dcd0/coverage-7.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903", size = 250325, upload-time = "2026-02-09T12:56:40.668Z" },
+    { url = "https://files.pythonhosted.org/packages/71/07/8c1542aa873728f72267c07278c5cc0ec91356daf974df21335ccdb46368/coverage-7.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f", size = 251913, upload-time = "2026-02-09T12:56:41.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d7/c62e2c5e4483a748e27868e4c32ad3daa9bdddbba58e1bc7a15e252baa74/coverage-7.13.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299", size = 249974, upload-time = "2026-02-09T12:56:43.323Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9f/4c5c015a6e98ced54efd0f5cf8d31b88e5504ecb6857585fc0161bb1e600/coverage-7.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505", size = 253741, upload-time = "2026-02-09T12:56:45.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/59/0f4eef89b9f0fcd9633b5d350016f54126ab49426a70ff4c4e87446cabdc/coverage-7.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6", size = 249695, upload-time = "2026-02-09T12:56:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2c/b7476f938deb07166f3eb281a385c262675d688ff4659ad56c6c6b8e2e70/coverage-7.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9", size = 250599, upload-time = "2026-02-09T12:56:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/34/c3420709d9846ee3785b9f2831b4d94f276f38884032dca1457fa83f7476/coverage-7.13.4-cp311-cp311-win32.whl", hash = "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9", size = 221780, upload-time = "2026-02-09T12:56:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/61/08/3d9c8613079d2b11c185b865de9a4c1a68850cfda2b357fae365cf609f29/coverage-7.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f", size = 222715, upload-time = "2026-02-09T12:56:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1a/54c3c80b2f056164cc0a6cdcb040733760c7c4be9d780fe655f356f433e4/coverage-7.13.4-cp311-cp311-win_arm64.whl", hash = "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f", size = 221385, upload-time = "2026-02-09T12:56:53.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/81/4ce2fdd909c5a0ed1f6dedb88aa57ab79b6d1fbd9b588c1ac7ef45659566/coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459", size = 219449, upload-time = "2026-02-09T12:56:54.889Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/96/5238b1efc5922ddbdc9b0db9243152c09777804fb7c02ad1741eb18a11c0/coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3", size = 219810, upload-time = "2026-02-09T12:56:56.33Z" },
+    { url = "https://files.pythonhosted.org/packages/78/72/2f372b726d433c9c35e56377cf1d513b4c16fe51841060d826b95caacec1/coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634", size = 251308, upload-time = "2026-02-09T12:56:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3", size = 254052, upload-time = "2026-02-09T12:56:59.754Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/45dc2e19a1939098d783c846e130b8f862fbb50d09e0af663988f2f21973/coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa", size = 255165, upload-time = "2026-02-09T12:57:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4d/26d236ff35abc3b5e63540d3386e4c3b192168c1d96da5cb2f43c640970f/coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3", size = 257432, upload-time = "2026-02-09T12:57:02.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/14a966c757d1348b2e19caf699415a2a4c4f7feaa4bbc6326a51f5c7dd1b/coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a", size = 251716, upload-time = "2026-02-09T12:57:04.056Z" },
+    { url = "https://files.pythonhosted.org/packages/77/33/50116647905837c66d28b2af1321b845d5f5d19be9655cb84d4a0ea806b4/coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7", size = 253089, upload-time = "2026-02-09T12:57:05.503Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/8efb11a46e3665d92635a56e4f2d4529de6d33f2cb38afd47d779d15fc99/coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc", size = 251232, upload-time = "2026-02-09T12:57:06.879Z" },
+    { url = "https://files.pythonhosted.org/packages/51/24/8cd73dd399b812cc76bb0ac260e671c4163093441847ffe058ac9fda1e32/coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47", size = 255299, upload-time = "2026-02-09T12:57:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/03/94/0a4b12f1d0e029ce1ccc1c800944a9984cbe7d678e470bb6d3c6bc38a0da/coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985", size = 250796, upload-time = "2026-02-09T12:57:10.142Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/6002fbf88f6698ca034360ce474c406be6d5a985b3fdb3401128031eef6b/coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0", size = 252673, upload-time = "2026-02-09T12:57:12.197Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c6/a0279f7c00e786be75a749a5674e6fa267bcbd8209cd10c9a450c655dfa7/coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246", size = 221990, upload-time = "2026-02-09T12:57:14.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4e/c0a25a425fcf5557d9abd18419c95b63922e897bc86c1f327f155ef234a9/coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126", size = 222800, upload-time = "2026-02-09T12:57:15.944Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ac/92da44ad9a6f4e3a7debd178949d6f3769bedca33830ce9b1dcdab589a37/coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d", size = 221415, upload-time = "2026-02-09T12:57:17.497Z" },
+    { url = "https://files.pythonhosted.org/packages/db/23/aad45061a31677d68e47499197a131eea55da4875d16c1f42021ab963503/coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9", size = 219474, upload-time = "2026-02-09T12:57:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/70/9b8b67a0945f3dfec1fd896c5cefb7c19d5a3a6d74630b99a895170999ae/coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac", size = 219844, upload-time = "2026-02-09T12:57:20.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/fd/7e859f8fab324cef6c4ad7cff156ca7c489fef9179d5749b0c8d321281c2/coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea", size = 250832, upload-time = "2026-02-09T12:57:22.007Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/dc/b2442d10020c2f52617828862d8b6ee337859cd8f3a1f13d607dddda9cf7/coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b", size = 253434, upload-time = "2026-02-09T12:57:23.339Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/88/6728a7ad17428b18d836540630487231f5470fb82454871149502f5e5aa2/coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525", size = 254676, upload-time = "2026-02-09T12:57:24.774Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bc/21244b1b8cedf0dff0a2b53b208015fe798d5f2a8d5348dbfece04224fff/coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242", size = 256807, upload-time = "2026-02-09T12:57:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a0/ddba7ed3251cff51006737a727d84e05b61517d1784a9988a846ba508877/coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148", size = 251058, upload-time = "2026-02-09T12:57:27.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/55/e289addf7ff54d3a540526f33751951bf0878f3809b47f6dfb3def69c6f7/coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a", size = 252805, upload-time = "2026-02-09T12:57:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/cc276b1fa4a59be56d96f1dabddbdc30f4ba22e3b1cd42504c37b3313255/coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23", size = 250766, upload-time = "2026-02-09T12:57:30.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/1093b8f93018f8b41a8cf29636c9292502f05e4a113d4d107d14a3acd044/coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80", size = 254923, upload-time = "2026-02-09T12:57:31.946Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/55/ea2796da2d42257f37dbea1aab239ba9263b31bd91d5527cdd6db5efe174/coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea", size = 250591, upload-time = "2026-02-09T12:57:33.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/7c4bb72aacf8af5020675aa633e59c1fbe296d22aed191b6a5b711eb2bc7/coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a", size = 252364, upload-time = "2026-02-09T12:57:35.743Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/38/a8d2ec0146479c20bbaa7181b5b455a0c41101eed57f10dd19a78ab44c80/coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d", size = 222010, upload-time = "2026-02-09T12:57:37.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0c/dbfafbe90a185943dcfbc766fe0e1909f658811492d79b741523a414a6cc/coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd", size = 222818, upload-time = "2026-02-09T12:57:38.734Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d1/934918a138c932c90d78301f45f677fb05c39a3112b96fd2c8e60503cdc7/coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af", size = 221438, upload-time = "2026-02-09T12:57:40.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/57/ee93ced533bcb3e6df961c0c6e42da2fc6addae53fb95b94a89b1e33ebd7/coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d", size = 220165, upload-time = "2026-02-09T12:57:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/969fc285a6fbdda49d91af278488d904dcd7651b2693872f0ff94e40e84a/coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12", size = 220516, upload-time = "2026-02-09T12:57:44.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b8/9531944e16267e2735a30a9641ff49671f07e8138ecf1ca13db9fd2560c7/coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b", size = 261804, upload-time = "2026-02-09T12:57:45.989Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f3/e63df6d500314a2a60390d1989240d5f27318a7a68fa30ad3806e2a9323e/coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9", size = 263885, upload-time = "2026-02-09T12:57:47.42Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/67/7654810de580e14b37670b60a09c599fa348e48312db5b216d730857ffe6/coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092", size = 266308, upload-time = "2026-02-09T12:57:49.345Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/39d41eca0eab3cc82115953ad41c4e77935286c930e8fad15eaed1389d83/coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9", size = 267452, upload-time = "2026-02-09T12:57:50.811Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6d/39c0fbb8fc5cd4d2090811e553c2108cf5112e882f82505ee7495349a6bf/coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26", size = 261057, upload-time = "2026-02-09T12:57:52.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a2/60010c669df5fa603bb5a97fb75407e191a846510da70ac657eb696b7fce/coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2", size = 263875, upload-time = "2026-02-09T12:57:53.938Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/63b22a6bdbd17f1f96e9ed58604c2a6b0e72a9133e37d663bef185877cf6/coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940", size = 261500, upload-time = "2026-02-09T12:57:56.012Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bf/69f86ba1ad85bc3ad240e4c0e57a2e620fbc0e1645a47b5c62f0e941ad7f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c", size = 265212, upload-time = "2026-02-09T12:57:57.5Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f2/5f65a278a8c2148731831574c73e42f57204243d33bedaaf18fa79c5958f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0", size = 260398, upload-time = "2026-02-09T12:57:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/80/6e8280a350ee9fea92f14b8357448a242dcaa243cb2c72ab0ca591f66c8c/coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b", size = 262584, upload-time = "2026-02-09T12:58:01.129Z" },
+    { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688, upload-time = "2026-02-09T12:58:02.736Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746, upload-time = "2026-02-09T12:58:05.362Z" },
+    { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003, upload-time = "2026-02-09T12:58:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lunardate"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/71/62fadf243502618cf2a7af5b81936a99684147c655729934f014758c3b39/lunardate-0.2.2.tar.gz", hash = "sha256:8ff8c01721bef7710f0712a302b1cb7d0b8b3ffc72a63a9a056cd01e58e5485a", size = 17686, upload-time = "2023-12-07T13:13:21.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/07/232401bb1c6bc699c5e641ad375e2582cdde90b19b18e6618ec51796b737/lunardate-0.2.2-py3-none-any.whl", hash = "sha256:cf1916337e50470a82df12d885ff47a456e89c91a3ad4e5fdf1575e063a7ed55", size = 18081, upload-time = "2023-12-07T13:13:19.333Z" },
+]
+
+[[package]]
+name = "multimethod"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/2d/6274e03d1d656f329f3546140a536fc728b68a1ef123d0deebc751541473/multimethod-2.0.2.tar.gz", hash = "sha256:4f753e9ef0eb08f25037fb7d04f3de22547716c4af257a978e1c4d660edab8f4", size = 15657, upload-time = "2025-11-18T01:16:33.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/3d/44e60142e058f7e41d0ab19e7f5cc9d77a00833fd6f0197dbbd4f13c0321/multimethod-2.0.2-py3-none-any.whl", hash = "sha256:e6e61347765ec0c154aef827bd6952a685a6693eb9d927fb530a6c364c77939e", size = 9561, upload-time = "2025-11-18T01:16:31.811Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "path"
+version = "17.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/52/a7bdd5ef8488977d354b7915d1e75009bebbd04f73eff14e52372d5e9435/path-17.1.1.tar.gz", hash = "sha256:2dfcbfec8b4d960f3469c52acf133113c2a8bf12ac7b98d629fa91af87248d42", size = 50528, upload-time = "2025-07-27T20:40:23.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/50/11c9ee1ede64b45d687fd36eb8768dafc57afc78b4d83396920cfd69ed30/path-17.1.1-py3-none-any.whl", hash = "sha256:ec7e136df29172e5030dd07e037d55f676bdb29d15bfa09b80da29d07d3b9303", size = 23936, upload-time = "2025-07-27T20:40:22.453Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyluach"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/11/42568c1568a75f8803c59f26d29af01a0890352b7a8e03d41ecda8bfb5dd/pyluach-2.3.0.tar.gz", hash = "sha256:ec6e30669d1df50c9ca160486da44a8195bb4c7a5d3d533990d0c5b03accd281", size = 26910, upload-time = "2025-09-09T20:24:39.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/c8/f96208ade3ca4c23b372497d0788bcf0f2e0ff4310e5ee693366bc33fdf0/pyluach-2.3.0-py3-none-any.whl", hash = "sha256:4497b731aef59508b079dbf5f00bc5bf4329ac45090a6cd37b5a83756f0e69ab", size = 25914, upload-time = "2025-09-09T20:24:37.831Z" },
+]
+
+[[package]]
+name = "pymeeus"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/76/599896b37e60f43078afd8354b3802eb7ca257a7e7f6253cc21c4c672877/PyMeeus-0.5.12.tar.gz", hash = "sha256:548f7186bd8b96cbc069cf649a8e8e377dce49ac74486709849fe63a99cad684", size = 5752712, upload-time = "2022-12-11T11:37:48.504Z" }
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-order"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
+]
+
+[[package]]
+name = "pytest-random-order"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/ad/a2a32d91effe0f84a300b9ba6c9d000bd52f31b77f8e49d8fd8653a9ddc3/pytest_random_order-1.2.0.tar.gz", hash = "sha256:12b2d4ee977ec9922b5e3575afe13c22cbdb06e3d03e550abc43df137b90439a", size = 107304, upload-time = "2025-06-22T14:44:43.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7f/92c8dbe185aa38270fec1e73e0ed70d8e5de31963aa057ba621055f8b008/pytest_random_order-1.2.0-py3-none-any.whl", hash = "sha256:78d1d6f346222cdf26a7302c502d2f1cab19454529af960b8b9e1427a99ab277", size = 10889, upload-time = "2025-06-22T14:44:42.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "work-tracker"
+source = { editable = "." }
+dependencies = [
+    { name = "appdirs" },
+    { name = "colorama" },
+    { name = "multimethod" },
+    { name = "packaging" },
+    { name = "path" },
+    { name = "prompt-toolkit" },
+    { name = "pydantic" },
+    { name = "pyperclip" },
+    { name = "pyyaml" },
+    { name = "workalendar" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pexpect" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "pytest-order" },
+    { name = "pytest-random-order" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "appdirs", specifier = ">=1.4.4" },
+    { name = "colorama", specifier = ">=0.4.6" },
+    { name = "multimethod", specifier = ">=2.0" },
+    { name = "packaging", specifier = ">=26.0" },
+    { name = "path", specifier = ">=17.1.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.48" },
+    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "pyperclip", specifier = ">=1.9.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "workalendar", specifier = ">=17.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pexpect", specifier = ">=4.9.0" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-order", specifier = ">=1.3.0" },
+    { name = "pytest-random-order", specifier = ">=1.1.1" },
+]
+
+[[package]]
+name = "workalendar"
+version = "17.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "convertdate" },
+    { name = "lunardate" },
+    { name = "pyluach" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/16/e2d59c5a3b2d01519778dc1820daab70054022d88ff8291df602b2620481/workalendar-17.0.0.tar.gz", hash = "sha256:b82d6024aed452505b01baf06dbe8d6309a3135ff1d39dee07c31b21ece853b4", size = 153468, upload-time = "2023-01-01T22:33:06.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/23/2fd9e240ae95be5653d57cc39d5377278eb376b4b3f30e27526d831b1668/workalendar-17.0.0-py3-none-any.whl", hash = "sha256:8fe1d6758f9a1af05d59cb81480afb912246ec7fa46e246b909897127cdbb1b0", size = 210652, upload-time = "2023-01-01T22:33:03.869Z" },
+]

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -132,7 +132,7 @@ class WorkTracker:
                 self.io.output("Invalid country code. Please input valid contry code.", color=Color.from_key(Config.data.output.error_color))
 
         self.data = AppData(country_code=country_code)
-        CheckpointManager.save("initial", self.data)
+        CheckpointManager.save("initial", self.data, add_suffix_timestamp=True)
 
         self.io.write(f"Everything is set up and ready.", color=Color.Cyan, end=" ")
         self.io.write(f"To view a list of available commands type {Color.Brightblue.value}help{Color.Reset.value}.", end=" ")
@@ -198,7 +198,7 @@ class WorkTracker:
         CheckpointManager.clear_cache()
 
     def _at_crash_exit(self, crash_message: str | None = None, exception: Exception | None = None):
-        CheckpointManager.save(f"crash-{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}", self.data)
+        CheckpointManager.save("crash", self.data, add_suffix_timestamp=True)
         with open(get_data_path().joinpath(f"crash-log-{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"), "w") as file:
             if crash_message is not None:
                 file.write(crash_message)
@@ -207,7 +207,7 @@ class WorkTracker:
         sys.exit()
 
     def _at_exit(self):
-        CheckpointManager.save(f"{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}", self.data)
+        CheckpointManager.save("exit", self.data, add_suffix_timestamp=True)
         sys.exit()
 
     def handle_exit_signal(self): # TODO check if this works | no it doesnt :(

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -225,7 +225,7 @@ class WorkTracker:
                 user_input: str = self.get_user_input(prefix)
                 error_log_last_processed_input = user_input
 
-                result: ParseResult = CommandParser.parse(user_input)
+                result: ParseResult = CommandParser.parse(user_input, self.state)
                 if result.error:
                     self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.Brightred)
                     continue

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -134,7 +134,7 @@ class WorkTracker:
         self.data = AppData(country_code=country_code)
         CheckpointManager.save("initial", self.data, add_suffix_timestamp=True)
 
-        self.io.write(f"Everything is set up and ready.", color=Color.Cyan, end=" ")
+        self.io.write("Everything is set up and ready.", color=Color.Cyan, end=" ")
         self.io.write(f"To view a list of available commands type {Color.Brightblue.value}help{Color.Reset.value}.", end=" ")
         self.io.write(f"For detailed information about a specific command use {Color.Brightblue.value}help <command_name>{Color.Reset.value}.", end=" ")
         self.io.write(f"It is recommended that you use {Color.Brightblue.value}tutorial{Color.Reset.value} command to quickly get familiar with the available features.", end=" ")
@@ -182,7 +182,7 @@ class WorkTracker:
 
             latest_version: str = result.stdout.strip().split("\n")[-1].split()[-1]
             return latest_version if installed_version != latest_version else None
-        except subprocess.SubprocessError as e:
+        except subprocess.SubprocessError:
             raise VersionCheckError("Subprocess error during version check.")
         except Exception as e:
             raise VersionCheckError(f"Unexpected error: {e}")
@@ -211,7 +211,7 @@ class WorkTracker:
         sys.exit()
 
     def handle_exit_signal(self): # TODO check if this works | no it doesnt :(
-        self._at_crash_exit(crash_message=f"received exit signal")
+        self._at_crash_exit(crash_message="received exit signal")
 
     def _run(self):
         error_log_last_processed_input: str = "None"

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -126,7 +126,7 @@ class WorkTracker:
             if country_code in valid_codes: # TODO use of private method
                 break
             else:
-                self.io.output("Invalid country code. Please input valid contry code.", color=Color.Brightred)
+                self.io.output("Invalid country code. Please input valid contry code.", color=Color.from_key(Config.data.output.error_color))
 
         self.data = AppData(country_code=country_code)
         CheckpointManager.save("initial", self.data)
@@ -227,16 +227,16 @@ class WorkTracker:
 
                 result: ParseResult = CommandParser.parse(user_input, self.state)
                 if result.error:
-                    self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.Brightred)
+                    self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.from_key(Config.data.output.error_color))
                     continue
 
                 for query in result.queries:
                     self.command_handler.run(query)
         except KeyboardInterrupt:
-            self.io.output("UNSAFE EXIT: saving data...", color=Color.Brightred, end="")
+            self.io.output("UNSAFE EXIT: saving data...", color=Color.from_key(Config.data.output.error_color), end="")
             self._at_exit()
         except Exception as exception:
-            self.io.output("FATAL ERROR: saving data and creating error log...", color=Color.Brightred, end="")
+            self.io.output("FATAL ERROR: saving data and creating error log...", color=Color.from_key(Config.data.output.error_color), end="")
             self._at_crash_exit(crash_message=f"{error_log_last_processed_input}\n\n", exception=exception)
 
     def start(self):

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -107,13 +107,6 @@ class WorkTracker:
             else:
                 self.io.output("Invalid country code. Please input valid contry code.", color=Color.Brightred)
 
-        self.io.output("Would you like to run the initial setup? This process can take some time but is recommended, as it enables the app to automatically fill your calendar with the suggested work schedule.")
-        user_input: str = self.io.input(f"{Config.data.input.prefix} ", custom_autocomplete=["yes", "no"])
-        if "yes".startswith(user_input):
-            self.io.output("Setup command is not yet implemented. Skipping setup phase...", color=Color.Brightred)
-        else:
-            self.io.output(f"Initial setup skipped. You can always run setup later by using {Color.Brightblue.value}setup{Color.Reset.value} command.")
-
         self.data = AppData(country_code=country_code)
         CheckpointManager.save("initial", self.data)
 

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -79,7 +79,10 @@ class WorkTracker:
         self._clear_old_cache()
 
         if not was_updated_since_last_launch and check_is_new_version_available and (latest_version := self._is_new_version_available()) is not None:
-            self._display_new_version_available_message(latest_version)
+            if parse_version(latest_version) > parse_version(__version__):
+                self._display_new_version_available_message(latest_version)
+            elif parse_version(latest_version) < parse_version(__version__):
+                self._display_running_newer_version_message(latest_version)
         self.io.output(f"Using {Color.Brightblue.value}WorkTracker{Color.Clear.value} version {Color.Brightblue.value}{__version__}{Color.Clear.value}.")
 
     def _get_previously_installed_version(self) -> str | None:
@@ -187,6 +190,9 @@ class WorkTracker:
     def _display_new_version_available_message(self, version: str):
         self.io.write(f"New version {Color.Brightcyan.value}{version}{Color.Reset.value} is available!", end=" ")
         self.io.output(f"Update with {Color.Brightblue.value}pip install --upgrade work-tracker{Color.Reset.value}.")
+
+    def _display_running_newer_version_message(self, latest_version_on_pip: str):
+        self.io.output(f"It seems like you are running a newer version ({Color.Brightblue.value}{__version__}{Color.Reset.value}) than the one available on pip ({Color.Brightblue.value}{latest_version_on_pip}{Color.Reset.value}). This may be the case if you are running a development version or if there was an issue retrieving the latest version from pip. {Color.Brightred.value}If you think this is an error, please report it{Color.Reset.value}.")
 
     def _clear_old_cache(self):
         CheckpointManager.clear_cache()

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 from pathlib import Path
 
+from packaging.version import parse as parse_version
 from workalendar.registry import registry
 
 from work_tracker import __version__
@@ -32,6 +33,7 @@ class WorkTracker:
     def initialize(self, check_is_new_version_available: bool = True):
         self._initialized = True
 
+        previously_installed_version: str | None = self._get_previously_installed_version()
         if is_first_time_launch := self._is_first_time_launch():
             self._create_basic_files()
         if was_version_file_missing := self._is_version_file_missing():
@@ -40,6 +42,8 @@ class WorkTracker:
             self._create_default_config_file()
         if was_macros_file_missing := self._is_macros_file_missing():
             self._create_default_macros_file()
+        if was_aliases_file_missing := self._is_aliases_file_missing():
+            self._create_default_aliases_file()
         if was_updated_since_last_launch := self._was_updated_since_last_launch():
             self._update_version_file()
 
@@ -57,6 +61,11 @@ class WorkTracker:
                 self.io.output("WARNING: config file could not be found. Default config will be used instead.", color=Color.Yellow)
             if was_macros_file_missing:
                 self.io.output("WARNING: macros file could not be found. Default macros will be used instead.", color=Color.Yellow)
+            if was_aliases_file_missing:
+                if was_updated_since_last_launch and previously_installed_version is not None and parse_version(previously_installed_version) < parse_version("0.2.0"):
+                    self.io.output("UPDATE: creating default aliases file due to version update.", color=Color.Brightblue)
+                else:
+                    self.io.output("WARNING: aliases file could not be found. Default aliases will be used instead.", color=Color.Yellow)
 
         if not is_first_time_launch:
             self._load_data()
@@ -73,19 +82,31 @@ class WorkTracker:
             self._display_new_version_available_message(latest_version)
         self.io.output(f"Using {Color.Brightblue.value}WorkTracker{Color.Clear.value} version {Color.Brightblue.value}{__version__}{Color.Clear.value}.")
 
+    def _get_previously_installed_version(self) -> str | None:
+        version_path: Path = get_data_path().joinpath("version")
+        if not version_path.exists():
+            return None
+
+        with open(version_path, "r") as file:
+            return file.read()
+
     def _is_first_time_launch(self) -> bool:
-        expected_files: list[Path] = [get_data_path().joinpath("version"), get_data_path().joinpath("config.yaml"), get_data_path().joinpath("macros.txt")]
+        expected_files: list[Path] = [get_data_path().joinpath("version"), get_data_path().joinpath("config.yaml"), get_data_path().joinpath("macros.txt"), get_data_path().joinpath("aliases.txt")]
         return all(not path.exists() for path in expected_files)
 
     def _create_basic_files(self):
         self._create_default_config_file()
         self._create_default_macros_file()
+        self._create_default_aliases_file()
 
     def _create_default_config_file(self):
         shutil.copy(Path(__file__).parent.joinpath("data/default.config.yaml"), get_data_path().joinpath("config.yaml"))
 
     def _create_default_macros_file(self):
         shutil.copy(Path(__file__).parent.joinpath("data/default.macros.txt"), get_data_path().joinpath("macros.txt"))
+
+    def _create_default_aliases_file(self):
+        shutil.copy(Path(__file__).parent.joinpath("data/default.aliases.txt"), get_data_path().joinpath("aliases.txt"))
 
     def _initialize_io(self):
         self.io = InputOutputHandler()
@@ -124,6 +145,9 @@ class WorkTracker:
 
     def _is_macros_file_missing(self) -> bool:
         return not get_data_path().joinpath("macros.txt").exists() # TODO make file name a constant
+
+    def _is_aliases_file_missing(self) -> bool:
+        return not get_data_path().joinpath("aliases.txt").exists() # TODO make file name a constant
 
     def _was_updated_since_last_launch(self) -> bool:
         path: Path = get_data_path().joinpath("version")

--- a/work_tracker/_work_tracker.py
+++ b/work_tracker/_work_tracker.py
@@ -74,6 +74,7 @@ class WorkTracker:
                 self._first_time_prompt()
             elif not self.data.is_latest_data_version():
                 self.data.update_data_to_latest_version()
+                CheckpointManager.save("update", self.data, add_suffix_timestamp=True)
 
         self._initialize_command_handler()
         self._clear_old_cache()

--- a/work_tracker/checkpoint_manager.py
+++ b/work_tracker/checkpoint_manager.py
@@ -2,11 +2,45 @@ import datetime
 import lzma
 import os
 import pickle
+from dataclasses import dataclass, field
+from enum import Enum, auto
 
 from path import Path
 
 from .common import AppData, get_data_path, get_cache_path
 
+
+# deprecated classes for unpickling old data - only used during initial load after update
+# === v1 start
+class _WorkStrategy(Enum):
+    Default = auto()
+    Quick = auto()
+
+
+@dataclass
+class _WorkSetup:
+    default_fte: float = 1.0
+    preferred_weekdays: list[int] = field(default_factory=list)
+    non_availability_weekdays: list[int] = field(default_factory=list)
+    default_remote_work_ratio: float = 0.4
+    preferred_remote_weekdays: list[int] = field(default_factory=list)
+    preferred_office_day_length_in_minutes: int | None = 480
+    preferred_remote_day_length_in_minutes: int | None = 480
+    office_day_max_length_in_minutes: int | None = 600
+    remote_day_max_length_in_minutes: int | None = 600
+    each_weekday_max_length_in_minutes: list[int | None] = field(default_factory=lambda: [None, None, None, None, None])
+    strategy: _WorkStrategy = _WorkStrategy.Default
+
+
+class _CompatibilityUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == 'work_tracker.common':
+            if name == 'WorkSetup':
+                return _WorkSetup
+            elif name == 'WorkStrategy':
+                return _WorkStrategy
+        return super().find_class(module, name)
+# === v1 end
 
 class CheckpointManager:
     @classmethod
@@ -21,7 +55,7 @@ class CheckpointManager:
         if not path.exists():
             return None
         with lzma.open(path, "rb") as file:
-            data: AppData = pickle.load(file)
+            data: AppData = _CompatibilityUnpickler(file).load()
         return data
 
     @staticmethod

--- a/work_tracker/checkpoint_manager.py
+++ b/work_tracker/checkpoint_manager.py
@@ -42,16 +42,17 @@ class _CompatibilityUnpickler(pickle.Unpickler):
         return super().find_class(module, name)
 # === v1 end
 
+
 class CheckpointManager:
     @classmethod
-    def load(cls, identifier: str, manual_checkpoint: bool = False) -> AppData | None: # TODO os exceptions
-        if manual_checkpoint:
-            for checkpoint_path in cls.all_manual_checkpoints():
+    def load(cls, identifier: str, persistent_checkpoint: bool = True) -> AppData | None: # TODO os exceptions
+        if not persistent_checkpoint:
+            for checkpoint_path in cls.all_temporary_checkpoints():
                 name, date = checkpoint_path.name.removesuffix('.save.checkpoint').split("__") # TODO hardcoded '.save.checkpoint'
                 if name == identifier:
                     identifier = f"{name}__{date}"
 
-        path: Path = (get_data_path() if not manual_checkpoint else get_cache_path()).joinpath(f"{identifier}.save.checkpoint")
+        path: Path = (get_data_path() if persistent_checkpoint else get_cache_path()).joinpath(f"{identifier}.save.checkpoint")
         if not path.exists():
             return None
         with lzma.open(path, "rb") as file:
@@ -59,27 +60,27 @@ class CheckpointManager:
         return data
 
     @staticmethod
-    def save(identifier: str, data: AppData, manual_checkpoint: bool = False): # TODO os exceptions
-        full_identifier: str = identifier if not manual_checkpoint else f"{identifier}__{datetime.datetime.now().strftime('%H-%M-%S')}"
-        path: Path = (get_data_path() if not manual_checkpoint else get_cache_path()).joinpath(f"{full_identifier}.save.checkpoint")
+    def save(identifier: str, data: AppData, persistent_checkpoint: bool = True, add_suffix_timestamp: bool = False, created_by_user: bool = False): # TODO os exceptions
+        full_identifier: str = identifier if not add_suffix_timestamp else f"{identifier}__{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+        path: Path = (get_data_path() if persistent_checkpoint else get_cache_path()).joinpath(f"{'user.' if created_by_user else ''}{full_identifier}.save.checkpoint") # TODO hardcoded 'user.'
         with lzma.open(path, "wb") as file:
             pickle.dump(data, file)
 
     @classmethod
     def load_latest(cls) -> AppData | None: # TODO os exceptions
-        files: list[Path] = cls.all_automatic_checkpoints()
+        files: list[Path] = cls.all_persistent_checkpoints()
         if not files:
             return None
 
-        newest_file: str = max(files, key=os.path.getctime) # TODO this sorting might be unclear for user
-        return cls.load(os.path.basename(newest_file.rstrip(".save.checkpoint")))
+        newest_file: Path = max(files, key=os.path.getctime) # TODO this sorting might be unclear for user
+        return cls.load(os.path.basename(newest_file.name.split('.')[0]))
 
     @staticmethod
-    def all_automatic_checkpoints() -> list[Path]: # TODO os exceptions
+    def all_persistent_checkpoints() -> list[Path]: # TODO os exceptions
         return [get_data_path().joinpath(file) for file in os.listdir(get_data_path()) if file.endswith(".save.checkpoint") and os.path.isfile(get_data_path().joinpath(file))]
 
     @staticmethod
-    def all_manual_checkpoints() -> list[Path]: # TODO os exceptions
+    def all_temporary_checkpoints() -> list[Path]: # TODO os exceptions
         return [get_cache_path().joinpath(file) for file in os.listdir(get_cache_path()) if file.endswith(".save.checkpoint") and os.path.isfile(get_cache_path().joinpath(file))]
 
     @staticmethod

--- a/work_tracker/checkpoint_manager.py
+++ b/work_tracker/checkpoint_manager.py
@@ -2,12 +2,22 @@ import datetime
 import lzma
 import os
 import pickle
+import re
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
 from path import Path
 
-from .common import AppData, get_data_path, get_cache_path
+from .common import AppData, get_data_path, get_cache_path, classproperty
+
+
+@dataclass(frozen=True)
+class CheckpointTemplate:
+    path: Path
+    full_identifier: str
+    name: str
+    date: str
+    persistent: bool
 
 
 # deprecated classes for unpickling old data - only used during initial load after update
@@ -44,44 +54,81 @@ class _CompatibilityUnpickler(pickle.Unpickler):
 
 
 class CheckpointManager:
+    _usermade_checkpoint_prefix: str = "user."
+    _checkpoint_suffix: str = ".save.checkpoint"
+
+    @classproperty
+    def usermade_checkpoint_prefix(cls) -> str:
+        return cls._usermade_checkpoint_prefix
+
+    @classproperty
+    def checkpoint_suffix(cls) -> str:
+        return cls._checkpoint_suffix
+
     @classmethod
     def load(cls, identifier: str, persistent_checkpoint: bool = True) -> AppData | None: # TODO os exceptions
         if not persistent_checkpoint:
-            for checkpoint_path in cls.all_temporary_checkpoints():
-                name, date = checkpoint_path.name.removesuffix('.save.checkpoint').split("__") # TODO hardcoded '.save.checkpoint'
-                if name == identifier:
-                    identifier = f"{name}__{date}"
+            for checkpoint in cls.temporary_checkpoints():
+                base_name: str = checkpoint.full_identifier.removesuffix(f"__{checkpoint.date}") if checkpoint.date != "-" else checkpoint.full_identifier
+                if base_name == identifier:
+                    identifier = checkpoint.full_identifier
 
-        path: Path = (get_data_path() if persistent_checkpoint else get_cache_path()).joinpath(f"{identifier}.save.checkpoint")
+        path: Path = (get_data_path() if persistent_checkpoint else get_cache_path()).joinpath(f"{identifier}{cls._checkpoint_suffix}")
         if not path.exists():
             return None
         with lzma.open(path, "rb") as file:
             data: AppData = _CompatibilityUnpickler(file).load()
         return data
 
-    @staticmethod
-    def save(identifier: str, data: AppData, persistent_checkpoint: bool = True, add_suffix_timestamp: bool = False, created_by_user: bool = False): # TODO os exceptions
+    @classmethod
+    def save(cls, identifier: str, data: AppData, persistent_checkpoint: bool = True, add_suffix_timestamp: bool = False, created_by_user: bool = False): # TODO os exceptions
         full_identifier: str = identifier if not add_suffix_timestamp else f"{identifier}__{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
-        path: Path = (get_data_path() if persistent_checkpoint else get_cache_path()).joinpath(f"{'user.' if created_by_user else ''}{full_identifier}.save.checkpoint") # TODO hardcoded 'user.'
+        path: Path = (get_data_path() if persistent_checkpoint else get_cache_path()).joinpath(f"{cls._usermade_checkpoint_prefix if created_by_user else ''}{full_identifier}{cls._checkpoint_suffix}")
         with lzma.open(path, "wb") as file:
             pickle.dump(data, file)
 
     @classmethod
     def load_latest(cls) -> AppData | None: # TODO os exceptions
-        files: list[Path] = cls.all_persistent_checkpoints()
-        if not files:
+        checkpoints: list[CheckpointTemplate] = cls.persistent_checkpoints()
+        if not checkpoints:
             return None
 
-        newest_file: Path = max(files, key=os.path.getctime) # TODO this sorting might be unclear for user
-        return cls.load(os.path.basename(newest_file.name.split('.')[0]))
+        newest: CheckpointTemplate = max(checkpoints, key=lambda c: os.path.getctime(c.path)) # TODO this sorting might be unclear for user
+        return cls.load(newest.full_identifier)
 
-    @staticmethod
-    def all_persistent_checkpoints() -> list[Path]: # TODO os exceptions
-        return [get_data_path().joinpath(file) for file in os.listdir(get_data_path()) if file.endswith(".save.checkpoint") and os.path.isfile(get_data_path().joinpath(file))]
+    @classmethod
+    def persistent_checkpoints(cls) -> list[CheckpointTemplate]: # TODO os exceptions
+        paths: list[Path] = [get_data_path().joinpath(file) for file in os.listdir(get_data_path()) if file.endswith(cls._checkpoint_suffix) and os.path.isfile(get_data_path().joinpath(file))]
+        return [cls._parse_checkpoint(path, persistent=True) for path in paths]
 
-    @staticmethod
-    def all_temporary_checkpoints() -> list[Path]: # TODO os exceptions
-        return [get_cache_path().joinpath(file) for file in os.listdir(get_cache_path()) if file.endswith(".save.checkpoint") and os.path.isfile(get_cache_path().joinpath(file))]
+    @classmethod
+    def temporary_checkpoints(cls) -> list[CheckpointTemplate]: # TODO os exceptions
+        paths: list[Path] = [get_cache_path().joinpath(file) for file in os.listdir(get_cache_path()) if file.endswith(cls._checkpoint_suffix) and os.path.isfile(get_cache_path().joinpath(file))]
+        return [cls._parse_checkpoint(path, persistent=False) for path in paths]
+
+    @classmethod
+    def checkpoints(cls) -> list[CheckpointTemplate]: # TODO os exceptions
+        return cls.temporary_checkpoints() + cls.persistent_checkpoints()
+
+    @classmethod
+    def _parse_checkpoint(cls, path: Path, persistent: bool) -> CheckpointTemplate:
+        raw_name: str = path.name.removesuffix(cls._checkpoint_suffix)
+        match: re.Match = re.match(r"(.+?)__(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})$", raw_name)
+        if match:
+            full_identifier: str = raw_name
+            name: str = match.group(1)
+            date: str = match.group(2)
+        else:
+            full_identifier: str = raw_name
+            name: str = raw_name
+            date: str = "-"
+        return CheckpointTemplate(
+            path=path,
+            full_identifier=full_identifier,
+            name=name,
+            date=date,
+            persistent=persistent
+        )
 
     @staticmethod
     def clear_cache():

--- a/work_tracker/command/alias_manager.py
+++ b/work_tracker/command/alias_manager.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from work_tracker.common import get_data_path, classproperty
+
+
+@dataclass(frozen=True)
+class AliasTemplate:
+    identifier: str
+    raw: str
+    replacement_text: str
+
+
+__alias_version__: int = 1
+
+
+class AliasManager:
+    _aliases: dict[str, AliasTemplate] = {}
+    _initialized: bool = False
+
+    @classproperty
+    def aliases(cls) -> dict[str, AliasTemplate]:
+        cls._check_initialization()
+        return cls._aliases # TODO deepcopy
+
+    @classproperty
+    def iterable_aliases(cls) -> list[AliasTemplate]:
+        cls._check_initialization()
+        return list(cls._aliases.values())
+
+    @classmethod
+    def _check_initialization(cls):
+        if not cls._initialized:
+            if not cls._is_latest_alias_version():
+                cls._update_aliases_to_latest_version()
+            cls._aliases = cls._initialize_aliases()
+            cls._initialized = True
+
+    @classmethod
+    def _is_latest_alias_version(cls) -> bool:
+        alias_path: Path = get_data_path().joinpath("aliases.txt")
+        with alias_path.open("r", encoding="utf-8") as file:
+            version: int = int(next(file))
+
+        return version == __alias_version__
+
+    @classmethod
+    def _update_aliases_to_latest_version(cls):
+        # just like data, update to target version step by step: A -> A+1 -> A+2 -> ... -> B
+        # remember to save the file, after update !
+        pass
+
+    @classmethod
+    def _initialize_aliases(cls) -> dict[str, AliasTemplate]:
+        alias_path: Path = get_data_path().joinpath("aliases.txt")
+
+        aliases: dict[str, AliasTemplate] = {}
+        with alias_path.open("r", encoding="utf-8") as file:
+            next(file) # skip first line with version number
+            lines: list[str] = file.readlines()
+            for line in lines:
+                line = line.strip()
+                if line is None or len(line) == 0:
+                    continue
+
+                parts: list[str] = line.split("|", 1)
+                if len(parts) != 2:
+                    raise Exception() # TODO
+
+                identifier: str = parts[0].strip()
+                replacement_text: str = parts[1].strip()
+
+                aliases[identifier] = AliasTemplate(
+                    identifier=identifier,
+                    raw=line,
+                    replacement_text=replacement_text,
+                )
+
+        return aliases
+
+    @classmethod
+    def update_alias(cls, alias: AliasTemplate):
+        cls._check_initialization()
+        cls._aliases[alias.identifier] = alias
+
+    @classmethod
+    def remove_alias(cls, alias: AliasTemplate):
+        cls._check_initialization()
+        cls._aliases.pop(alias.identifier)
+
+    @classmethod
+    def save_aliases_file(cls):
+        alias_path: Path = get_data_path().joinpath("aliases.txt")
+        with alias_path.open("w", encoding="utf-8") as file:
+            file.write(f"{__alias_version__}\n")
+            for alias in cls.iterable_aliases:
+                file.write(f"{alias.raw}\n")

--- a/work_tracker/command/command_initializer.py
+++ b/work_tracker/command/command_initializer.py
@@ -16,7 +16,7 @@ class CommandInitializer:
 
         commands_dict: dict[str, CommandTemplate] = {command.name: command for command in commands}
         if len(commands_dict.keys()) != len(commands):
-            raise RuntimeError(f"Could not initialize commands, there are duplicated command names.")
+            raise RuntimeError("Could not initialize commands, there are duplicated command names.")
 
         cls._find_not_conflicting_shortest_command_string_for(commands)
 

--- a/work_tracker/command/command_manager.py
+++ b/work_tracker/command/command_manager.py
@@ -1,6 +1,6 @@
 from work_tracker.command.command_initializer import CommandInitializer
 from work_tracker.command.common import Command, TimeArgument, CommandHelp, _global_command_templates
-from work_tracker.common import Mode
+from work_tracker.common import Mode, classproperty
 
 
 class CommandManager:
@@ -53,23 +53,19 @@ class CommandManager:
         valid_argument_types=[[object, ...]]
     )
 
-    @classmethod
-    @property
+    @classproperty
     def time_command(cls) -> Command:
         return cls._time_command
 
-    @classmethod
-    @property
+    @classproperty
     def date_command(cls) -> Command:
         return cls._date_command
 
-    @classmethod
-    @property
+    @classproperty
     def macro_execute_command(cls) -> Command:
         return cls._macro_execute_command
 
-    @classmethod
-    @property
+    @classproperty
     def commands(cls) -> list[Command]:
         if len(cls._commands) == 0:
             cls._commands = CommandInitializer.initialize_commands(_global_command_templates)

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -6,7 +6,7 @@ from typing import get_origin, get_args
 from work_tracker.command.command_manager import CommandManager
 from work_tracker.command.command_text_parser import CommandTextParser
 from work_tracker.command.common import Command, CommandQuery, Date, CommandArgument, TimeArgument, TimeArgumentType, ParseResult, Number, AdditionalInputArgument
-from work_tracker.error import ParserError, ParserErrorMultipleDates, ParserErrorInvalidArgumentCount, ParserErrorInvalidArgumentTypes, ParserErrorUnknownCommand
+from work_tracker.error import ParserError, ParserErrorMultipleDates, ParserErrorInvalidArgumentCount, ParserErrorInvalidArgumentTypes, ParserErrorUnknownCommand, ParserErrorMultipleDatesInvalidSyntax
 from work_tracker.command.macro_manager import MacroManager
 from work_tracker.common import month_map
 from work_tracker.config import Config
@@ -36,6 +36,9 @@ class CommandParser:
             is_first_command_in_chain: bool = index == 0
             if is_first_command_in_chain and cls._has_multi_command_dates(parser):
                 multi_dates = cls._get_multi_command_dates(parser) # TODO fix, this does not check if the multi_end_string is required so input '(<date> <date>...' is valid
+                if len(multi_dates) == 0:
+                    error = ParserErrorMultipleDatesInvalidSyntax()
+                    break
 
             predefined_command_arguments: list[CommandArgument] = []
             dates: list[Date] = cls._get_dates(parser)
@@ -49,7 +52,7 @@ class CommandParser:
             elif parser.peak() is None and len(dates) > 1: # situation where only dates are provided
                 error = ParserErrorMultipleDates()
                 break
-            elif parser.peak() in MacroManager.macros: # TODO macro
+            elif parser.peak() in MacroManager.macros:
                 command: Command = CommandManager.macro_execute_command
                 predefined_command_arguments.append(parser.next())
             else:
@@ -120,23 +123,30 @@ class CommandParser:
 
     @classmethod
     def _get_multi_command_dates(cls, parser: CommandTextParser) -> list[Date]:
-        if parser.peak() == Config.data.input.multi_date_start_symbol:
-            parser.next()
-        return cls._get_dates(parser, multi_command_dates=True)
+        return cls._get_dates(parser, require_multi_command_date_symbols=True)
 
     @classmethod
-    def _get_dates(cls, parser: CommandTextParser, multi_command_dates: bool = False) -> list[Date]:
+    def _get_dates(cls, parser: CommandTextParser, require_multi_command_date_symbols: bool = False) -> list[Date]:
         parsed_dates: list[Date] = []
         force_break: bool = False
         first_word: bool = True
+        seen_multi_date_end_symbol: bool = False
         while word := parser.peak(): # TODO split the 'Config.data.input.multi_date_end_symbol' logic into _get_multi_command_dates ?
-            if multi_command_dates and first_word and word != Config.data.input.multi_date_start_symbol and word.startswith(Config.data.input.multi_date_start_symbol):
-                word = word[len(Config.data.input.multi_date_start_symbol):]
+            if require_multi_command_date_symbols and first_word:
                 first_word = False
-            if multi_command_dates and word == Config.data.input.multi_date_end_symbol:
+                if word == Config.data.input.multi_date_start_symbol:
+                    parser.next()
+                    continue
+                elif word.startswith(Config.data.input.multi_date_start_symbol):
+                    word = word[len(Config.data.input.multi_date_start_symbol):]
+                else:
+                    break
+            elif require_multi_command_date_symbols and word == Config.data.input.multi_date_end_symbol:
+                seen_multi_date_end_symbol = True
                 parser.next()
                 break
-            if multi_command_dates and word.endswith(Config.data.input.multi_date_end_symbol):
+            elif require_multi_command_date_symbols and word.endswith(Config.data.input.multi_date_end_symbol):
+                seen_multi_date_end_symbol = True
                 word = word[:-len(Config.data.input.multi_date_end_symbol)]
                 force_break = True
             
@@ -150,7 +160,10 @@ class CommandParser:
             if force_break:
                 break
 
-        return Date.normalize_dates(parsed_dates, preserve_order=True) # TODO normalize too aggressive in some cases, allow user to turn it off ?
+        if require_multi_command_date_symbols and not seen_multi_date_end_symbol:
+            return []
+        else:
+            return Date.normalize_dates(parsed_dates, preserve_order=True) # TODO normalize too aggressive in some cases, allow user to turn it off ?
 
     @classmethod
     def _extract_date(cls, text: str) -> Date | None:

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -28,6 +28,7 @@ class CommandParser:
 
     @classmethod
     def parse(cls, text: str) -> ParseResult:
+        original_text: str = text
         text = re.sub(r"\s+", " ", text)
         text_per_command: list[str] = cls._split_text_per_command(text)
         queries: list[CommandQuery] = []
@@ -93,9 +94,15 @@ class CommandParser:
                 command=command,
                 dates=final_dates,
                 date_count=len(final_dates),
+                own_dates=dates,
+                own_date_count=len(dates),
+                multi_dates=multi_dates,
+                multi_dates_count=len(multi_dates),
                 arguments=command_arguments,
                 argument_count=len(command_arguments),
-                raw_text=text
+                raw_text=text,
+                raw_full_input=original_text,
+                order_index=index
             ))
 
         return ParseResult(

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -12,13 +12,6 @@ from work_tracker.common import month_map
 from work_tracker.config import Config
 
 
-# TODO move to config
-multi_command_dates_start_string: str = "("
-multi_command_dates_end_string: str = ")"
-time_argument_add_prefix_string: str = "+"
-time_argument_subtract_prefix_string: str = "-"
-
-
 class CommandParser:
     _date_pattern: str = r'^(?:(\d{1,2}))?\.(?:(\d{1,2})(?:\.(\d{1,2}|\d{4})?)?)?$' # e.g. DD.MM.YYYY, DD.MM.YY, DD.MM, DD., .MM., .MM.YYYY
     _year_pattern: str = r'^(\d{4})$' # e.g. YYYY
@@ -123,11 +116,11 @@ class CommandParser:
 
     @classmethod
     def _has_multi_command_dates(cls, parser: CommandTextParser) -> bool:
-        return parser.peak().startswith(multi_command_dates_start_string)
+        return parser.peak().startswith(Config.data.input.multi_date_start_symbol)
 
     @classmethod
     def _get_multi_command_dates(cls, parser: CommandTextParser) -> list[Date]:
-        if parser.peak() == multi_command_dates_start_string:
+        if parser.peak() == Config.data.input.multi_date_start_symbol:
             parser.next()
         return cls._get_dates(parser, multi_command_dates=True)
 
@@ -136,15 +129,15 @@ class CommandParser:
         parsed_dates: list[Date] = []
         force_break: bool = False
         first_word: bool = True
-        while word := parser.peak(): # TODO split the 'multi_command_dates_end_string' logic into _get_multi_command_dates ?
-            if multi_command_dates and first_word and word != multi_command_dates_start_string and word.startswith(multi_command_dates_start_string):
-                word = word[len(multi_command_dates_start_string):]
+        while word := parser.peak(): # TODO split the 'Config.data.input.multi_date_end_symbol' logic into _get_multi_command_dates ?
+            if multi_command_dates and first_word and word != Config.data.input.multi_date_start_symbol and word.startswith(Config.data.input.multi_date_start_symbol):
+                word = word[len(Config.data.input.multi_date_start_symbol):]
                 first_word = False
-            if multi_command_dates and word == multi_command_dates_end_string:
+            if multi_command_dates and word == Config.data.input.multi_date_end_symbol:
                 parser.next()
                 break
-            if multi_command_dates and word.endswith(multi_command_dates_end_string):
-                word = word[:-len(multi_command_dates_end_string)]
+            if multi_command_dates and word.endswith(Config.data.input.multi_date_end_symbol):
+                word = word[:-len(Config.data.input.multi_date_end_symbol)]
                 force_break = True
             
             date: Date | None = cls._extract_date(word)
@@ -233,15 +226,15 @@ class CommandParser:
         parser.checkpoint()
         argument_type: TimeArgumentType = TimeArgumentType.Overwrite
         text: str = parser.peak()
-        if text == time_argument_add_prefix_string:
+        if text == Config.data.input.time_add_prefix:
             argument_type = TimeArgumentType.Add
             parser.next()
-        elif text.startswith(time_argument_add_prefix_string):
+        elif text.startswith(Config.data.input.time_add_prefix):
             argument_type = TimeArgumentType.Add
-        elif text == time_argument_subtract_prefix_string:
+        elif text == Config.data.input.time_subtract_prefix:
             argument_type = TimeArgumentType.Subtract
             parser.next()
-        elif text.startswith(time_argument_subtract_prefix_string):
+        elif text.startswith(Config.data.input.time_subtract_prefix):
             argument_type = TimeArgumentType.Subtract
 
         minutes: int = cls._get_minute_count(parser)
@@ -307,10 +300,10 @@ class CommandParser:
         if text is None:
             parser.go_to_checkpoint()
             return None
-        elif text.startswith(time_argument_add_prefix_string):
-            text = text[len(time_argument_add_prefix_string):]
-        elif text.startswith(time_argument_subtract_prefix_string):
-            text = text[len(time_argument_subtract_prefix_string):]
+        elif text.startswith(Config.data.input.time_add_prefix):
+            text = text[len(Config.data.input.time_add_prefix):]
+        elif text.startswith(Config.data.input.time_subtract_prefix):
+            text = text[len(Config.data.input.time_subtract_prefix):]
 
         minutes: int = cls._extract_minute_count(text)
         if minutes is not None:

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -3,6 +3,7 @@ import re
 from fractions import Fraction
 from typing import get_origin, get_args
 
+from work_tracker.command.alias_manager import AliasManager
 from work_tracker.command.command_manager import CommandManager
 from work_tracker.command.command_text_parser import CommandTextParser
 from work_tracker.command.common import Command, CommandQuery, Date, CommandArgument, TimeArgument, TimeArgumentType, ParseResult, Number, AdditionalInputArgument
@@ -23,6 +24,7 @@ class CommandParser:
     def parse(cls, text: str) -> ParseResult:
         original_text: str = text
         text = re.sub(r"\s+", " ", text)
+        text = cls.expand_aliases(text)
         text_per_command: list[str] = cls._split_text_per_command(text)
         queries: list[CommandQuery] = []
         error: ParserError | None = None
@@ -105,6 +107,35 @@ class CommandParser:
             queries=queries,
             error=error,
         )
+    
+    @classmethod
+    def expand_aliases(cls, text: str, max_depth: int = 32) -> str:
+        token_pattern: re.Pattern = re.compile(r'("[^"]*"|\'[^\']*\'|\S+)') # respect text inside quotes, dont expand aliases inside
+
+        for _ in range(max_depth):
+            tokens: list[str] = token_pattern.findall(text)
+            if not tokens:
+                break
+
+            changed: bool = False
+            result: list[str] = []
+            for token in tokens:
+                is_quoted: bool = (token.startswith('"') and token.endswith('"')) or \
+                                  (token.startswith("'") and token.endswith("'"))
+
+                if not is_quoted and token.lower() in AliasManager.aliases:
+                    replacement_text: str = AliasManager.aliases[token.lower()].replacement_text
+                    result.extend(replacement_text.split())
+                    changed = True
+                else:
+                    result.append(token)
+
+            if not changed:
+                break
+
+            text = " ".join(result)
+
+        return text
 
     @classmethod
     def _split_text_per_command(cls, text: str) -> list[str]: # TODO add tests

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -62,9 +62,7 @@ class CommandParser:
             else:
                 command_string: str = parser.next()
                 is_valid_command_string: bool = cls._is_valid_command_string(command_string)
-                if not is_valid_command_string and len(dates) == 1: # this is here to properly catch errors further ahead when reading arguments
-                    command: Command = CommandManager.date_command
-                elif not is_valid_command_string:
+                if not is_valid_command_string:
                     error = ParserErrorUnknownCommand(
                         received_name=command_string
                     )
@@ -250,8 +248,8 @@ class CommandParser:
         elif year_match:
             year = int(year_match.group())
             return Date(day=None, month=None, year=year)
-        elif text in month_map:
-            return Date(day=None, month=month_map[text], year=None)
+        elif text.lower() in month_map:
+            return Date(day=None, month=month_map[text.lower()], year=None)
         else:
             return None
 
@@ -340,7 +338,10 @@ class CommandParser:
         if "/" in text:
             return float(Fraction(text))
         elif "%" in text:
-            return float(text.strip('%')) / 100
+            try:
+                return float(text.strip('%')) / 100
+            except ValueError:
+                return None
         else:
             try:
                 value: Number = int(text)

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -7,9 +7,10 @@ from work_tracker.command.alias_manager import AliasManager
 from work_tracker.command.command_manager import CommandManager
 from work_tracker.command.command_text_parser import CommandTextParser
 from work_tracker.command.common import Command, CommandQuery, Date, CommandArgument, TimeArgument, TimeArgumentType, ParseResult, Number, AdditionalInputArgument
+from work_tracker.command.keyword_manager import KeywordManager
 from work_tracker.error import ParserError, ParserErrorMultipleDates, ParserErrorInvalidArgumentCount, ParserErrorInvalidArgumentTypes, ParserErrorUnknownCommand, ParserErrorMultipleDatesInvalidSyntax
 from work_tracker.command.macro_manager import MacroManager
-from work_tracker.common import month_map
+from work_tracker.common import ReadonlyAppState, month_map
 from work_tracker.config import Config
 
 
@@ -21,10 +22,11 @@ class CommandParser:
     _time_pattern: str = r'^\d+:\d{2}$' # e.g. 1:20, 2:30
 
     @classmethod
-    def parse(cls, text: str) -> ParseResult:
+    def parse(cls, text: str, state: ReadonlyAppState) -> ParseResult:
         original_text: str = text
         text = re.sub(r"\s+", " ", text)
         text = cls.expand_aliases(text)
+        text = cls.activate_keywords(text, state)
         text_per_command: list[str] = cls._split_text_per_command(text)
         queries: list[CommandQuery] = []
         error: ParserError | None = None
@@ -135,6 +137,28 @@ class CommandParser:
 
             text = " ".join(result)
 
+        return text
+    
+    @classmethod
+    def activate_keywords(cls, text: str, state: ReadonlyAppState) -> str:
+        prefix: str = Config.data.input.keyword_prefix
+        
+        token_pattern: re.Pattern = re.compile(r'("[^"]*"|\'[^\']*\'|\S+)')
+        tokens: list[str] = token_pattern.findall(text)
+        
+        for token in tokens:
+            is_quoted: bool = (token.startswith('"') and token.endswith('"')) or \
+                              (token.startswith("'") and token.endswith("'"))
+            if is_quoted:
+                continue
+            
+            if token.startswith(prefix):
+                keyword_without_prefix: str = token[len(prefix):]
+                if keyword_without_prefix.lower() in KeywordManager.keywords:
+                    value: str = KeywordManager.get_keyword_value(keyword_without_prefix, state)
+                    if value:
+                        text = text.replace(token, value)
+        
         return text
 
     @classmethod

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -37,7 +37,7 @@ class CommandParser:
             
             is_first_command_in_chain: bool = index == 0
             if is_first_command_in_chain and cls._has_multi_command_dates(parser):
-                multi_dates = cls._get_multi_command_dates(parser) # TODO fix, this does not check if the multi_end_string is required so input '(<date> <date>...' is valid
+                multi_dates = cls._get_multi_command_dates(parser)
                 if len(multi_dates) == 0:
                     error = ParserErrorMultipleDatesInvalidSyntax()
                     break

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -36,7 +36,6 @@ class CommandParser:
         multi_dates: list[Date] = []
         for index, text in enumerate(text_per_command):
             parser: CommandTextParser = CommandTextParser(text)
-            dates: list[Date] = []
             if parser.peak() is None:
                 continue
             
@@ -45,16 +44,10 @@ class CommandParser:
                 multi_dates = cls._get_multi_command_dates(parser) # TODO fix, this does not check if the multi_end_string is required so input '(<date> <date>...' is valid
 
             predefined_command_arguments: list[CommandArgument] = []
+            dates: list[Date] = cls._get_dates(parser)
             command: Command = None
-            if (time := cls._get_time(parser)) is not None:
-                command = CommandManager.time_command
-                predefined_command_arguments.append(time)
-            else:
-                dates = cls._get_dates(parser)
 
-            if command is not None:
-                pass
-            elif parser.peak() is not None and (time := cls._get_time(parser)) is not None:
+            if parser.peak() is not None and (time := cls._get_time(parser)) is not None:
                 command: Command = CommandManager.time_command
                 predefined_command_arguments.append(time)
             elif parser.peak() is None and len(dates) == 1:

--- a/work_tracker/command/command_parser.py
+++ b/work_tracker/command/command_parser.py
@@ -87,7 +87,7 @@ class CommandParser:
                 )
                 break
 
-            final_dates: list[Date] = Date.normalize_dates(multi_dates + dates, preserve_order=True) # TODO allow user to turn off normalization
+            final_dates: list[Date] = Date.normalize_dates(multi_dates + dates, preserve_order=True) if Config.data.input.date.normalize else (multi_dates + dates)
             queries.append(CommandQuery(
                 command=command,
                 dates=final_dates,
@@ -172,7 +172,7 @@ class CommandParser:
 
     @classmethod
     def _has_multi_command_dates(cls, parser: CommandTextParser) -> bool:
-        return parser.peak().startswith(Config.data.input.multi_date_start_symbol)
+        return parser.peak().startswith(Config.data.input.date.multi_start_symbol)
 
     @classmethod
     def _get_multi_command_dates(cls, parser: CommandTextParser) -> list[Date]:
@@ -184,23 +184,23 @@ class CommandParser:
         force_break: bool = False
         first_word: bool = True
         seen_multi_date_end_symbol: bool = False
-        while word := parser.peak(): # TODO split the 'Config.data.input.multi_date_end_symbol' logic into _get_multi_command_dates ?
+        while word := parser.peak(): # TODO split the 'Config.data.input.date.multi_end_symbol' logic into _get_multi_command_dates ?
             if require_multi_command_date_symbols and first_word:
                 first_word = False
-                if word == Config.data.input.multi_date_start_symbol:
+                if word == Config.data.input.date.multi_start_symbol:
                     parser.next()
                     continue
-                elif word.startswith(Config.data.input.multi_date_start_symbol):
-                    word = word[len(Config.data.input.multi_date_start_symbol):]
+                elif word.startswith(Config.data.input.date.multi_start_symbol):
+                    word = word[len(Config.data.input.date.multi_start_symbol):]
                 else:
                     break
-            elif require_multi_command_date_symbols and word == Config.data.input.multi_date_end_symbol:
+            elif require_multi_command_date_symbols and word == Config.data.input.date.multi_end_symbol:
                 seen_multi_date_end_symbol = True
                 parser.next()
                 break
-            elif require_multi_command_date_symbols and word.endswith(Config.data.input.multi_date_end_symbol):
+            elif require_multi_command_date_symbols and word.endswith(Config.data.input.date.multi_end_symbol):
                 seen_multi_date_end_symbol = True
-                word = word[:-len(Config.data.input.multi_date_end_symbol)]
+                word = word[:-len(Config.data.input.date.multi_end_symbol)]
                 force_break = True
             
             date: Date | None = cls._extract_date(word)
@@ -216,7 +216,7 @@ class CommandParser:
         if require_multi_command_date_symbols and not seen_multi_date_end_symbol:
             return []
         else:
-            return Date.normalize_dates(parsed_dates, preserve_order=True) # TODO normalize too aggressive in some cases, allow user to turn it off ?
+            return Date.normalize_dates(parsed_dates, preserve_order=True) if Config.data.input.date.normalize else parsed_dates
 
     @classmethod
     def _extract_date(cls, text: str) -> Date | None:
@@ -292,15 +292,15 @@ class CommandParser:
         parser.checkpoint()
         argument_type: TimeArgumentType = TimeArgumentType.Overwrite
         text: str = parser.peak()
-        if text == Config.data.input.time_add_prefix:
+        if text == Config.data.input.time.add_prefix:
             argument_type = TimeArgumentType.Add
             parser.next()
-        elif text.startswith(Config.data.input.time_add_prefix):
+        elif text.startswith(Config.data.input.time.add_prefix):
             argument_type = TimeArgumentType.Add
-        elif text == Config.data.input.time_subtract_prefix:
+        elif text == Config.data.input.time.subtract_prefix:
             argument_type = TimeArgumentType.Subtract
             parser.next()
-        elif text.startswith(Config.data.input.time_subtract_prefix):
+        elif text.startswith(Config.data.input.time.subtract_prefix):
             argument_type = TimeArgumentType.Subtract
 
         minutes: int = cls._get_minute_count(parser)
@@ -369,10 +369,10 @@ class CommandParser:
         if text is None:
             parser.go_to_checkpoint()
             return None
-        elif text.startswith(Config.data.input.time_add_prefix):
-            text = text[len(Config.data.input.time_add_prefix):]
-        elif text.startswith(Config.data.input.time_subtract_prefix):
-            text = text[len(Config.data.input.time_subtract_prefix):]
+        elif text.startswith(Config.data.input.time.add_prefix):
+            text = text[len(Config.data.input.time.add_prefix):]
+        elif text.startswith(Config.data.input.time.subtract_prefix):
+            text = text[len(Config.data.input.time.subtract_prefix):]
 
         minutes: int = cls._extract_minute_count(text)
         if minutes is not None:

--- a/work_tracker/command/command_query_handler.py
+++ b/work_tracker/command/command_query_handler.py
@@ -58,7 +58,9 @@ class CommandQueryHandler:
             self._during_execute_after = False
 
         if result.undoable and not self._during_execute_after:
-            self._history.add(KeyManager.encode(self.data), query.raw_text)
+            # TODO: move these to config and use config, hardcoded for now so i dont get any looped imports
+            multi_dates_text: str = ("(" + query.raw_full_input.split("(")[1].split(")")[0] + ") ") if query.multi_dates_count != 0 and query.order_index != 0 else ''
+            self._history.add(KeyManager.encode(self.data), f"{multi_dates_text}{query.raw_text}")
         if result.error is not None:
             self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.Brightred)
         if result.change_active_date is not None:

--- a/work_tracker/command/command_query_handler.py
+++ b/work_tracker/command/command_query_handler.py
@@ -50,11 +50,10 @@ class CommandQueryHandler:
 
     def run(self, query: CommandQuery):
         result: CommandHandlerResult = self._handlers[query.command.name].handle(query.dates, query.date_count, query.arguments, query.argument_count, self._readonly_app_state())
-
         if result.execute_after is not None:
             self._during_execute_after = True
-            for query in result.execute_after:
-                self.run(query)
+            for subquery in result.execute_after:
+                self.run(subquery)
             self._during_execute_after = False
 
         if result.undoable and not self._during_execute_after:

--- a/work_tracker/command/command_query_handler.py
+++ b/work_tracker/command/command_query_handler.py
@@ -65,7 +65,7 @@ class CommandQueryHandler:
                 else ''
             self._history.add(KeyManager.encode(self.data), f"{multi_dates_text}{query.raw_text}")
         if result.error is not None:
-            self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.Brightred)
+            self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.from_key(Config.data.output.error_color))
         if result.change_active_date is not None:
             self.state.active_date = result.change_active_date
             if self.state.active_date == Date.today():

--- a/work_tracker/command/command_query_handler.py
+++ b/work_tracker/command/command_query_handler.py
@@ -58,9 +58,9 @@ class CommandQueryHandler:
 
         if result.undoable and not self._during_execute_after:
             multi_dates_text: str = \
-                (Config.data.input.multi_date_start_symbol
-                 + query.raw_full_input.split(Config.data.input.multi_date_start_symbol)[1].split(Config.data.input.multi_date_end_symbol)[0]
-                 + Config.data.input.multi_date_end_symbol + " ") \
+                (Config.data.input.date.multi_start_symbol
+                 + query.raw_full_input.split(Config.data.input.date.multi_start_symbol)[1].split(Config.data.input.date.multi_end_symbol)[0]
+                 + Config.data.input.date.multi_end_symbol + " ") \
                 if query.multi_dates_count != 0 and query.order_index != 0 \
                 else ''
             self._history.add(KeyManager.encode(self.data), f"{multi_dates_text}{query.raw_text}")

--- a/work_tracker/command/command_query_handler.py
+++ b/work_tracker/command/command_query_handler.py
@@ -58,8 +58,12 @@ class CommandQueryHandler:
             self._during_execute_after = False
 
         if result.undoable and not self._during_execute_after:
-            # TODO: move these to config and use config, hardcoded for now so i dont get any looped imports
-            multi_dates_text: str = ("(" + query.raw_full_input.split("(")[1].split(")")[0] + ") ") if query.multi_dates_count != 0 and query.order_index != 0 else ''
+            multi_dates_text: str = \
+                (Config.data.input.multi_date_start_symbol
+                 + query.raw_full_input.split(Config.data.input.multi_date_start_symbol)[1].split(Config.data.input.multi_date_end_symbol)[0]
+                 + Config.data.input.multi_date_end_symbol + " ") \
+                if query.multi_dates_count != 0 and query.order_index != 0 \
+                else ''
             self._history.add(KeyManager.encode(self.data), f"{multi_dates_text}{query.raw_text}")
         if result.error is not None:
             self.io.output(f"ERROR: {result.error.message or 'missing error description'}", color=Color.Brightred)

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -24,41 +24,34 @@ class __MacroHandler(CommandHandler):
             )
 
         given_arguments: list[any] = arguments[1:]
-        required_argument_count: int = len([argument for argument in macro.default_argument_values if argument is None])
         given_argument_count: int = len(given_arguments)
-        argument_suffix: str = "argument" if required_argument_count == 1 else "arguments"
-        if required_argument_count == 0 and given_argument_count > 0:
-            message: str = f"macro {macro_identifier} expects no arguments, but {given_argument_count} were provided." if given_argument_count > 1 else f"macro {macro_identifier} expects no arguments, but 1 was provided."
+
+        max_accepted_argument_count: int = len(macro.default_argument_values)
+        min_required_argument_count: int = len([argument for argument in macro.default_argument_values if argument is None])
+
+        # TODO: really dont like using nested methods, but this is a quick fix
+        def plural_argument(count: int) -> str: return "argument" if count == 1 else "arguments"
+        def plural_be(count: int) -> str: return "was" if count == 1 else "were"
+
+        if given_argument_count > max_accepted_argument_count:
+            if max_accepted_argument_count == 0:
+                message = f"macro {macro_identifier} expects no arguments, but {given_argument_count} {plural_be(given_argument_count)} provided."
+            else:
+                message = f"macro {macro_identifier} expects at most {max_accepted_argument_count} {plural_argument(max_accepted_argument_count)}, but {given_argument_count} {plural_be(given_argument_count)} provided."
+
             return CommandHandlerResult(
                 undoable=False,
-                error=CommandErrorCustom(
-                    command_name=self.command_name,
-                    custom_message=message
-                )
+                error=CommandErrorCustom(command_name=self.command_name, custom_message=message)
             )
-        elif required_argument_count != 0 and given_argument_count == 0:
+        elif given_argument_count < min_required_argument_count:
+            if given_argument_count == 0:
+                message = f"macro {macro_identifier} requires at least {min_required_argument_count} {plural_argument(min_required_argument_count)}, but no arguments were provided."
+            else:
+                message = f"macro {macro_identifier} requires at least {min_required_argument_count} {plural_argument(min_required_argument_count)}, but only {given_argument_count} {plural_be(given_argument_count)} provided."
+
             return CommandHandlerResult(
                 undoable=False,
-                error=CommandErrorCustom(
-                    command_name=self.command_name,
-                    custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but no values were provided."
-                )
-            )
-        elif required_argument_count != 0 and given_argument_count < required_argument_count:
-            return CommandHandlerResult(
-                undoable=False,
-                error=CommandErrorCustom(
-                    command_name=self.command_name,
-                    custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but only {given_argument_count} values were provided."
-                )
-            )
-        elif required_argument_count != 0 and given_argument_count > required_argument_count:
-            return CommandHandlerResult(
-                undoable=False,
-                error=CommandErrorCustom(
-                    command_name=self.command_name,
-                    custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but {given_argument_count} values were provided."
-                )
+                error=CommandErrorCustom(command_name=self.command_name, custom_message=message)
             )
 
         macro_arguments: list[str] = macro.default_argument_values.copy()

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -25,16 +25,43 @@ class __MacroHandler(CommandHandler):
 
         given_arguments: list[any] = arguments[1:]
         required_argument_count: int = len([argument for argument in macro.default_argument_values if argument is None])
-        if len(given_arguments) < required_argument_count:
+        given_argument_count: int = len(given_arguments)
+        argument_suffix: str = "argument" if required_argument_count == 1 else "arguments"
+        if required_argument_count == 0 and given_argument_count > 0:
+            message: str = f"macro {macro_identifier} expects no arguments, but {given_argument_count} were provided." if given_argument_count > 1 else f"macro {macro_identifier} expects no arguments, but 1 was provided."
             return CommandHandlerResult(
                 undoable=False,
                 error=CommandErrorCustom(
                     command_name=self.command_name,
-                    custom_message=f"macro {macro_identifier} requires {required_argument_count} arguments but only {len(given_arguments)} values were provided. Please provide the missing arguments."
+                    custom_message=message
+                )
+            )
+        elif given_argument_count == 0: # required_argument_count != 0
+            return CommandHandlerResult(
+                undoable=False,
+                error=CommandErrorCustom(
+                    command_name=self.command_name,
+                    custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but no values were provided."
+                )
+            )
+        elif given_argument_count < required_argument_count: # required_argument_count != 0
+            return CommandHandlerResult(
+                undoable=False,
+                error=CommandErrorCustom(
+                    command_name=self.command_name,
+                    custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but only {given_argument_count} values were provided."
+                )
+            )
+        elif given_argument_count > required_argument_count: # required_argument_count != 0
+            return CommandHandlerResult(
+                undoable=False,
+                error=CommandErrorCustom(
+                    command_name=self.command_name,
+                    custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but {given_argument_count} values were provided."
                 )
             )
 
-        macro_arguments: list[any] = macro.default_argument_values
+        macro_arguments: list[str] = macro.default_argument_values.copy()
         macro_arguments[:len(given_arguments)] = given_arguments
         command_text: str = macro.command_text
         for index, argument_identifier in enumerate(macro.arguments):

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -1,8 +1,9 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.command_parser import CommandParser
-from work_tracker.command.common import CommandArgument, ParseResult, CommandQuery
+from work_tracker.command.common import CommandArgument, ParseResult, CommandQuery, TimeArgument, TimeArgumentType
 from work_tracker.command.macro_manager import MacroManager, MacroTemplate
 from work_tracker.common import Date, ReadonlyAppState
+from work_tracker.config import Config
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorCustom
 from dataclasses import replace
 
@@ -55,7 +56,7 @@ class __MacroHandler(CommandHandler):
             )
 
         macro_arguments: list[str] = macro.default_argument_values.copy()
-        macro_arguments[:len(given_arguments)] = given_arguments
+        macro_arguments[:len(given_arguments)] = [self._format_argument(argument) for argument in given_arguments]
         command_text: str = macro.command_text
         for index, argument_identifier in enumerate(macro.arguments):
             command_text = command_text.replace(f"<{argument_identifier}>", macro_arguments[index])
@@ -75,3 +76,14 @@ class __MacroHandler(CommandHandler):
             new_dates: list[Date] = query.dates + dates
             queries[index] = replace(query, dates=new_dates, date_count=new_dates.__len__())
         return CommandHandlerResult(undoable=True, execute_after=queries)
+
+    @staticmethod
+    def _format_argument(argument: CommandArgument) -> str:
+        if isinstance(argument, TimeArgument):
+            if argument.type == TimeArgumentType.Add:
+                return f"{Config.data.input.time_add_prefix}{argument.minutes}m"
+            elif argument.type == TimeArgumentType.Subtract:
+                return f"{Config.data.input.time_subtract_prefix}{argument.minutes}m"
+            else:
+                return f"{argument.minutes}m"
+        return str(argument)

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -1,3 +1,6 @@
+from dataclasses import replace
+from typing import Any
+
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.command_parser import CommandParser
 from work_tracker.command.common import CommandArgument, ParseResult, CommandQuery, TimeArgument, TimeArgumentType
@@ -5,7 +8,6 @@ from work_tracker.command.macro_manager import MacroManager, MacroTemplate
 from work_tracker.common import Date, ReadonlyAppState
 from work_tracker.config import Config
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorCustom
-from dataclasses import replace
 
 
 class __MacroHandler(CommandHandler):
@@ -72,8 +74,8 @@ class __MacroHandler(CommandHandler):
             )
 
         queries: list[CommandQuery] = interpret_result.queries
-        for index, query in enumerate(queries): # TODO: this is quite ugly, but works, here date normalization is OMITTED !
-            new_dates: list[Date] = query.dates + dates
+        for index, query in enumerate(queries): # TODO: this is quite ugly, but works
+            new_dates: list[Date] = Date.normalize_dates(query.dates + dates, preserve_order=True) if Config.data.input.date.normalize else query.dates + dates
             queries[index] = replace(query, dates=new_dates, date_count=new_dates.__len__())
         return CommandHandlerResult(undoable=True, execute_after=queries)
 
@@ -81,9 +83,9 @@ class __MacroHandler(CommandHandler):
     def _format_argument(argument: CommandArgument) -> str:
         if isinstance(argument, TimeArgument):
             if argument.type == TimeArgumentType.Add:
-                return f"{Config.data.input.time_add_prefix}{argument.minutes}m"
+                return f"{Config.data.input.time.add_prefix}{argument.minutes}m"
             elif argument.type == TimeArgumentType.Subtract:
-                return f"{Config.data.input.time_subtract_prefix}{argument.minutes}m"
+                return f"{Config.data.input.time.subtract_prefix}{argument.minutes}m"
             else:
                 return f"{argument.minutes}m"
         return str(argument)

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -60,7 +60,7 @@ class __MacroHandler(CommandHandler):
         for index, argument_identifier in enumerate(macro.arguments):
             command_text = command_text.replace(f"<{argument_identifier}>", macro_arguments[index])
 
-        interpret_result: ParseResult = CommandParser.parse(command_text)
+        interpret_result: ParseResult = CommandParser.parse(command_text, state)
         if interpret_result.error is not None:
             return CommandHandlerResult(
                 undoable=False,

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -36,7 +36,7 @@ class __MacroHandler(CommandHandler):
                     custom_message=message
                 )
             )
-        elif given_argument_count == 0: # required_argument_count != 0
+        elif required_argument_count != 0 and given_argument_count == 0:
             return CommandHandlerResult(
                 undoable=False,
                 error=CommandErrorCustom(
@@ -44,7 +44,7 @@ class __MacroHandler(CommandHandler):
                     custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but no values were provided."
                 )
             )
-        elif given_argument_count < required_argument_count: # required_argument_count != 0
+        elif required_argument_count != 0 and given_argument_count < required_argument_count:
             return CommandHandlerResult(
                 undoable=False,
                 error=CommandErrorCustom(
@@ -52,7 +52,7 @@ class __MacroHandler(CommandHandler):
                     custom_message=f"macro {macro_identifier} requires {required_argument_count} {argument_suffix}, but only {given_argument_count} values were provided."
                 )
             )
-        elif given_argument_count > required_argument_count: # required_argument_count != 0
+        elif required_argument_count != 0 and given_argument_count > required_argument_count:
             return CommandHandlerResult(
                 undoable=False,
                 error=CommandErrorCustom(

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -4,12 +4,12 @@ from work_tracker.command.common import CommandArgument, ParseResult, CommandQue
 from work_tracker.command.macro_manager import MacroManager, MacroTemplate
 from work_tracker.common import Date, ReadonlyAppState
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorCustom
+from dataclasses import replace
 
 
 class __MacroHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if argument_count == 0:
-            print(arguments)
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
         macro_identifier: str = arguments[0]
@@ -51,4 +51,7 @@ class __MacroHandler(CommandHandler):
             )
 
         queries: list[CommandQuery] = interpret_result.queries
+        for index, query in enumerate(queries): # TODO: this is quite ugly, but works, here date normalization is OMITTED !
+            new_dates: list[Date] = query.dates + dates
+            queries[index] = replace(query, dates=new_dates, date_count=new_dates.__len__())
         return CommandHandlerResult(undoable=True, execute_after=queries)

--- a/work_tracker/command/commands/__macro.py
+++ b/work_tracker/command/commands/__macro.py
@@ -24,7 +24,7 @@ class __MacroHandler(CommandHandler):
                 )
             )
 
-        given_arguments: list[any] = arguments[1:]
+        given_arguments: list[Any] = arguments[1:]
         given_argument_count: int = len(given_arguments)
 
         max_accepted_argument_count: int = len(macro.default_argument_values)

--- a/work_tracker/command/commands/absence.py
+++ b/work_tracker/command/commands/absence.py
@@ -4,7 +4,7 @@ from work_tracker.common import Date, AttendanceType, DayType, ReadonlyAppState,
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
-class DayoffHandler(CommandHandler):
+class AbsenceHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 0:
             match state.mode:
@@ -18,7 +18,6 @@ class DayoffHandler(CommandHandler):
         elif date_count != 0 and argument_count == 0:
             if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
-                
             for date in dates:
                 if date.is_day_date():
                     self._handle_day(date.fill_with(state.active_date))
@@ -29,8 +28,8 @@ class DayoffHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
-        date = date.fill_with_today().to_day_date()
-        self.data.day[date].attendance_type = AttendanceType.DAYOFF
+        filled_date: Date = date.fill_with_today().to_day_date()
+        self.data.day[filled_date].attendance_type = AttendanceType.ABSENCE
 
     def _handle_month(self, date: Date):
         date = date.fill_with_today().to_month_date()

--- a/work_tracker/command/commands/absence.py
+++ b/work_tracker/command/commands/absence.py
@@ -35,4 +35,4 @@ class AbsenceHandler(CommandHandler):
         date = date.fill_with_today().to_month_date()
         for day in date.days_in_a_month():
             if self.data.day[day].day_type == DayType.WORKDAY:
-                self._handle_day(date)
+                self._handle_day(day)

--- a/work_tracker/command/commands/alias.py
+++ b/work_tracker/command/commands/alias.py
@@ -1,0 +1,64 @@
+from work_tracker.error import CommandErrorInvalidDateCount
+from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
+from work_tracker.command.common import CommandArgument
+from work_tracker.command.alias_manager import AliasManager, AliasTemplate
+from work_tracker.common import Date, ReadonlyAppState
+from work_tracker.text.common import wrap_text, frame_text, Color
+
+
+class AliasHandler(CommandHandler):
+    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
+        # TODO add pagination
+        if date_count == 0 and argument_count == 0:
+            raw_texts: list[str] = [alias.raw for alias in AliasManager.iterable_aliases]
+            alias_identifiers: list[str] = [text.split("|", 1)[0].strip() for text in raw_texts]
+            alias_replacements: list[str] = [text.split("|", 1)[1].strip() if "|" in text else "" for text in raw_texts]
+
+            longest_identifier_size: int = max(len(identifier) for identifier in alias_identifiers)
+
+            # TODO add ellipsis here and in other places modifiable by user (custom methods in the future)
+            # TODO what if identifier is very long => solution: set max length in config and add ellipsis if its too long
+            separator: str = " | " # TODO make separator configurable, but the read logic must be changed too
+            alias_texts: list[str] = []
+            for index, (identifier, replacement) in enumerate(zip(alias_identifiers, alias_replacements)):
+                replacement_wrapped: str = wrap_text(
+                    text=replacement,
+                    indent=" "*(longest_identifier_size + len(separator)),
+                    omit_first_line_indent=True,
+                    frame_wrap=True
+                )
+                alias_texts.append(f"{Color.Brightblack.value if index % 2 == 1 else Color.Reset.value}{identifier.rjust(longest_identifier_size)}{separator}{replacement_wrapped}")
+
+            framed_text: str = frame_text(
+                text="\n".join(alias_texts),
+                title="Aliases",
+                title_color=Color.Bold
+            )
+            self.io.output(framed_text)
+            return CommandHandlerResult(undoable=False)
+        elif date_count == 0 and argument_count == 1:
+            alias_identifier: str = arguments[0]
+            if alias_identifier in AliasManager.aliases:
+                self.io.output(AliasManager.aliases[alias_identifier].raw)
+            else:
+                self.io.output(f"Could not find alias named {alias_identifier}.")
+            return CommandHandlerResult(undoable=False)
+        elif date_count == 0 and argument_count >= 2:
+            alias_identifier: str = arguments[0]
+            replacement_text: str = " ".join(str(arg) for arg in arguments[1:])
+
+            # alias cant be named 'alias' nor 'deletealias' to prevent softlocking user out of creating/updating aliases
+            if alias_identifier.lower() in ["alias", "deletealias"]:
+                self.io.output("Alias identifier cannot be 'alias' or 'deletealias'.")
+                return CommandHandlerResult(undoable=False)
+            
+            alias: AliasTemplate = AliasTemplate(
+                identifier=alias_identifier,
+                raw=f"{alias_identifier} | {replacement_text}",
+                replacement_text=replacement_text,
+            )
+            AliasManager.update_alias(alias)
+            AliasManager.save_aliases_file()
+            return CommandHandlerResult(undoable=False)
+        else: # date_count != 0
+            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))

--- a/work_tracker/command/commands/block.py
+++ b/work_tracker/command/commands/block.py
@@ -1,9 +1,0 @@
-from work_tracker.command.common import CommandArgument
-from work_tracker.error import CommandErrorNotImplemented
-from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
-from work_tracker.common import Date, ReadonlyAppState
-
-
-class BlockHandler(CommandHandler):
-    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        return CommandHandlerResult(undoable=False, error=CommandErrorNotImplemented(command_name=self.command_name))

--- a/work_tracker/command/commands/calculate.py
+++ b/work_tracker/command/commands/calculate.py
@@ -1,9 +1,0 @@
-from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
-from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState
-from work_tracker.error import CommandErrorNotImplemented
-
-
-class CalculateHandler(CommandHandler):
-    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        return CommandHandlerResult(undoable=False, error=CommandErrorNotImplemented(command_name=self.command_name))

--- a/work_tracker/command/commands/calendar.py
+++ b/work_tracker/command/commands/calendar.py
@@ -4,17 +4,20 @@ from enum import Enum, auto
 
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, find_first_not_fulfilling
+from work_tracker.common import Date, AttendanceType, DayType, WorkLocation, ReadonlyAppState, find_first_not_fulfilling
 from work_tracker.config import Config, CalendarCommandConfig
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidDateCount
 from work_tracker.text.common import Color, frame_text
 
 
 class CalendarDateType(Enum):
+    Absence = auto()
     Dayoff = auto()
     Holiday = auto()
     Office = auto()
+    IncompleteOffice = auto()
     Remote = auto()
+    IncompleteRemote = auto()
     Weekend = auto()
 
 
@@ -75,11 +78,14 @@ class CalendarHandler(CommandHandler):
 
     def _get_each_date_type_dates(self, month: Date) -> dict[CalendarDateType, list[Date]]:
         return {
-            CalendarDateType.Dayoff: [date for date in month.days_in_a_month() if self.data.day[date].is_a_day_off],
-            CalendarDateType.Holiday: [date for date in month.days_in_a_month() if not self.data.day[date].is_a_work_day and not date.to_datetime().isoweekday() in (6, 7)],
-            CalendarDateType.Office: [date for date in month.days_in_a_month() if self.data.day[date].is_a_work_day and self.data.day[date].office_work and not self.data.day[date].is_a_day_off],
-            CalendarDateType.Remote: [date for date in month.days_in_a_month() if self.data.day[date].is_a_work_day and self.data.day[date].remote_work and not self.data.day[date].is_a_day_off],
-            CalendarDateType.Weekend: [date for date in month.days_in_a_month() if not self.data.day[date].is_a_work_day and date.to_datetime().isoweekday() in (6, 7)],
+            CalendarDateType.Absence: [date for date in month.days_in_a_month() if self.data.day[date].attendance_type == AttendanceType.ABSENCE],
+            CalendarDateType.Dayoff: [date for date in month.days_in_a_month() if self.data.day[date].attendance_type == AttendanceType.DAYOFF],
+            CalendarDateType.IncompleteOffice: [date for date in month.days_in_a_month() if self.data.day[date].work_location == WorkLocation.OFFICE and (self.data.day[date].minutes_at_work < self.data.day[date].target_minutes or self.data.day[date].target_minutes == 0)],
+            CalendarDateType.Office: [date for date in month.days_in_a_month() if self.data.day[date].work_location == WorkLocation.OFFICE],
+            CalendarDateType.IncompleteRemote: [date for date in month.days_in_a_month() if self.data.day[date].work_location == WorkLocation.REMOTE and (self.data.day[date].minutes_at_work < self.data.day[date].target_minutes or self.data.day[date].target_minutes == 0)],
+            CalendarDateType.Remote: [date for date in month.days_in_a_month() if self.data.day[date].work_location == WorkLocation.REMOTE],
+            CalendarDateType.Holiday: [date for date in month.days_in_a_month() if self.data.day[date].day_type == DayType.HOLIDAY],
+            CalendarDateType.Weekend: [date for date in month.days_in_a_month() if self.data.day[date].day_type == DayType.WEEKEND],
         }
 
     @staticmethod
@@ -87,10 +93,13 @@ class CalendarHandler(CommandHandler):
         calendar_config: CalendarCommandConfig = Config.data.command.calendar
 
         return {
+            CalendarDateType.Absence: CalendarHandler._get_color(calendar_config.absence_foreground_color, calendar_config.absence_background_color),
             CalendarDateType.Dayoff: CalendarHandler._get_color(calendar_config.dayoff_foreground_color, calendar_config.dayoff_background_color),
-            CalendarDateType.Holiday: CalendarHandler._get_color(calendar_config.holiday_foreground_color, calendar_config.holiday_background_color),
+            CalendarDateType.IncompleteOffice: CalendarHandler._get_color(calendar_config.office_incomplete_foreground_color, calendar_config.office_incomplete_background_color),
             CalendarDateType.Office: CalendarHandler._get_color(calendar_config.office_foreground_color, calendar_config.office_background_color),
+            CalendarDateType.IncompleteRemote: CalendarHandler._get_color(calendar_config.remote_incomplete_foreground_color, calendar_config.remote_incomplete_background_color),
             CalendarDateType.Remote: CalendarHandler._get_color(calendar_config.remote_foreground_color, calendar_config.remote_background_color),
+            CalendarDateType.Holiday: CalendarHandler._get_color(calendar_config.holiday_foreground_color, calendar_config.holiday_background_color),
             CalendarDateType.Weekend: CalendarHandler._get_color(calendar_config.weekend_foreground_color, calendar_config.weekend_background_color),
         }
 

--- a/work_tracker/command/commands/checkpoint.py
+++ b/work_tracker/command/commands/checkpoint.py
@@ -17,6 +17,10 @@ class CheckpointHandler(CommandHandler):
                 checkpoint_name: str = checkpoint_path.name.removesuffix('.save.checkpoint') # TODO hardcoded '.save.checkpoint'
                 match: re.Match = re.search(r'__(?!.*__)', checkpoint_name)
                 checkpoints.append((checkpoint_name[:match.start()], checkpoint_name[match.end():]))
+            if len(checkpoints) == 0:
+                self.io.output(f"No checkpoints were yet created, create one via {Color.Brightblue.value}checkpoint <name>{Color.Reset.value}.")
+                return CommandHandlerResult(undoable=False)
+
             sorted_checkpoints_by_time: list[tuple[str, str]] = sorted(checkpoints, key=lambda checkpoint: checkpoint[1])
 
             seperator: str = " | " # TODO make seperator configurable

--- a/work_tracker/command/commands/checkpoint.py
+++ b/work_tracker/command/commands/checkpoint.py
@@ -1,48 +1,139 @@
 import datetime
+import os
 import re
+from dataclasses import dataclass
+
+from path import Path
 
 from work_tracker.checkpoint_manager import CheckpointManager
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import Date, ReadonlyAppState
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDateCount
-from work_tracker.text.common import Color, wrap_text, frame_text
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDateCount, CommandErrorInvalidArgumentValue
+from work_tracker.text.common import Color, wrap_text, frame_text, strip_ansi
 
+
+@dataclass(frozen=True)
+class CheckpointTemplate:
+    path: Path
+    name: str
+    date: str
+    persistent: bool
+
+# TODO: fix rollback
+# TODO: handle same name checkpoints
 
 class CheckpointHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 0:
-            checkpoints: list[tuple[str, str]] = []
-            for index, checkpoint_path in enumerate(CheckpointManager.all_manual_checkpoints()):
-                checkpoint_name: str = checkpoint_path.name.removesuffix('.save.checkpoint') # TODO hardcoded '.save.checkpoint'
-                match: re.Match = re.search(r'__(?!.*__)', checkpoint_name)
-                checkpoints.append((checkpoint_name[:match.start()], checkpoint_name[match.end():]))
+            checkpoints: list[CheckpointTemplate] = []
+            for index, checkpoint_path in enumerate([checkpoint for checkpoint in CheckpointManager.all_temporary_checkpoints() if checkpoint.name.startswith("user.")]): # TODO hardcoded 'user.'
+                raw_name: str = checkpoint_path.name.removesuffix('.save.checkpoint') # TODO hardcoded '.save.checkpoint'
+                match: re.Match = re.match(r"user\.(.+?)__(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})", raw_name)
+                if match:
+                    name: str = match.group(1)
+                    date: str = match.group(2)
+                else:
+                    name: str = raw_name
+                    date: str = "-"
+                checkpoints.append(CheckpointTemplate(
+                    path=checkpoint_path,
+                    name=name,
+                    date=date,
+                    persistent=False
+                ))
+            for index, checkpoint_path in enumerate([checkpoint for checkpoint in CheckpointManager.all_persistent_checkpoints() if checkpoint.name.startswith("user.")]):
+                raw_name: str = checkpoint_path.name.removesuffix('.save.checkpoint') # TODO hardcoded '.save.checkpoint'
+                match: re.Match = re.match(r"user\.(.+?)__(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})", raw_name)
+                if match:
+                    name: str = match.group(1)
+                    date: str = match.group(2)
+                else:
+                    name: str = raw_name
+                    date: str = "-"
+                checkpoints.append(CheckpointTemplate(
+                    path=checkpoint_path,
+                    name=name,
+                    date=date,
+                    persistent=True
+                ))
             if len(checkpoints) == 0:
                 self.io.output(f"No checkpoints were yet created, create one via {Color.Brightblue.value}checkpoint <name>{Color.Reset.value}.")
                 return CommandHandlerResult(undoable=False)
 
-            sorted_checkpoints_by_time: list[tuple[str, str]] = sorted(checkpoints, key=lambda checkpoint: checkpoint[1])
+            sorted_checkpoints_by_time: list[CheckpointTemplate] = sorted(checkpoints, key=lambda checkpoint: os.path.getctime(checkpoint.path)) # TODO this sorting might be unclear for user
 
-            seperator: str = " | " # TODO make seperator configurable
-            checkpoints_text: list[str] = [
-                f"{Color.Brightblack.value if index % 2 == 1 else Color.Reset.value}{date.replace('-', ':')}{seperator}{identifier}"
-                for index, (identifier, date) in enumerate(sorted_checkpoints_by_time)
+            formatted_dates: list[str] = [
+                checkpoint.date if checkpoint.date == "-" else datetime.datetime.strptime(checkpoint.date, "%Y-%m-%d_%H-%M-%S").strftime("%d-%m-%Y %H:%M:%S")
+                for checkpoint in sorted_checkpoints_by_time
             ]
-            wrapped_text: str = wrap_text(
-                text="\n".join(checkpoints_text),
-                frame_wrap=True,
+
+            longest_index_size: int = len(str(len(sorted_checkpoints_by_time))) if sorted_checkpoints_by_time else 1
+            longest_date_size: int = max((len(date) for date in formatted_dates), default=0)
+
+            separator: str = " | " # TODO make separator configurable
+            checkpoints_text: list[str] = []
+
+            for index, checkpoint in enumerate(sorted_checkpoints_by_time):
+                index_padded: str = str(index + 1).ljust(longest_index_size)
+                date_padded: str = formatted_dates[index].ljust(longest_date_size)
+
+                indent_size: int = longest_index_size + len(separator) + longest_date_size + len(separator)
+                indent: str = " " * indent_size
+
+                wrapped_name: str = wrap_text(
+                    text=checkpoint.name,
+                    indent=indent,
+                    omit_first_line_indent=True,
+                    frame_wrap=True
+                )
+
+                is_temporary: bool = not checkpoint.persistent
+                if is_temporary:
+                    color: str = Color.Red.value if index % 2 == 1 else Color.Brightred.value
+                else:
+                    color: str = Color.Brightblack.value if index % 2 == 1 else Color.Reset.value
+
+                checkpoints_text.append(
+                    f"{color}{index_padded}{color}{separator}{date_padded}{color}{separator}{wrapped_name}"
+                )
+
+            wrapped_text: str = "\n".join(checkpoints_text)
+
+            footer_text: str = wrap_text(
+                text=f"Checkpoints in {Color.Red.value}red{Color.Reset.value} are temporary and will be automatically deleted after exiting the app.",
+                frame_wrap=True
             )
+
+            wrapped_lines_len: list[int] = [len(strip_ansi(line)) for line in wrapped_text.splitlines()]
+            footer_lines_len: list[int] = [len(strip_ansi(line)) for line in footer_text.splitlines()]
+            longest_line_width: int = max(wrapped_lines_len + footer_lines_len, default=0)
+
             framed_text: str = frame_text(
                 text=wrapped_text,
                 title="Checkpoints",
-                title_color=Color.Bold
+                title_color=Color.Bold,
+                skip_bottom_line=True,
+                minimal_line_width=longest_line_width
             )
-            self.io.output(framed_text)
+            framed_footer_text: str = frame_text(
+                text=footer_text,
+                extend_top_line=True,
+                minimal_line_width=longest_line_width
+            )
 
+            self.io.write(framed_text)
+            self.io.output(framed_footer_text)
             return CommandHandlerResult(undoable=False)
         elif date_count == 0 and argument_count == 1:
             checkpoint_identifier: str = arguments[0]
-            CheckpointManager.save(checkpoint_identifier, self.data, manual_checkpoint=True)
+            CheckpointManager.save(checkpoint_identifier, self.data, persistent_checkpoint=False, add_suffix_timestamp=True, created_by_user=True)
+            return CommandHandlerResult(undoable=False)
+        elif date_count == 0 and argument_count == 2:
+            if not "permanent".startswith(arguments[1]):
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="permanent"))
+            checkpoint_identifier: str = arguments[0]
+            CheckpointManager.save(checkpoint_identifier, self.data, persistent_checkpoint=True, add_suffix_timestamp=True, created_by_user=True)
             return CommandHandlerResult(undoable=False)
         elif date_count != 0:
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))

--- a/work_tracker/command/commands/checkpoint.py
+++ b/work_tracker/command/commands/checkpoint.py
@@ -1,11 +1,7 @@
 import datetime
 import os
-import re
-from dataclasses import dataclass
 
-from path import Path
-
-from work_tracker.checkpoint_manager import CheckpointManager
+from work_tracker.checkpoint_manager import CheckpointManager, CheckpointTemplate
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import Date, ReadonlyAppState
@@ -13,50 +9,11 @@ from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInv
 from work_tracker.text.common import Color, wrap_text, frame_text, strip_ansi
 
 
-@dataclass(frozen=True)
-class CheckpointTemplate:
-    path: Path
-    name: str
-    date: str
-    persistent: bool
-
-# TODO: fix rollback
-# TODO: handle same name checkpoints
-
 class CheckpointHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 0:
-            checkpoints: list[CheckpointTemplate] = []
-            for index, checkpoint_path in enumerate([checkpoint for checkpoint in CheckpointManager.all_temporary_checkpoints() if checkpoint.name.startswith("user.")]): # TODO hardcoded 'user.'
-                raw_name: str = checkpoint_path.name.removesuffix('.save.checkpoint') # TODO hardcoded '.save.checkpoint'
-                match: re.Match = re.match(r"user\.(.+?)__(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})", raw_name)
-                if match:
-                    name: str = match.group(1)
-                    date: str = match.group(2)
-                else:
-                    name: str = raw_name
-                    date: str = "-"
-                checkpoints.append(CheckpointTemplate(
-                    path=checkpoint_path,
-                    name=name,
-                    date=date,
-                    persistent=False
-                ))
-            for index, checkpoint_path in enumerate([checkpoint for checkpoint in CheckpointManager.all_persistent_checkpoints() if checkpoint.name.startswith("user.")]):
-                raw_name: str = checkpoint_path.name.removesuffix('.save.checkpoint') # TODO hardcoded '.save.checkpoint'
-                match: re.Match = re.match(r"user\.(.+?)__(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})", raw_name)
-                if match:
-                    name: str = match.group(1)
-                    date: str = match.group(2)
-                else:
-                    name: str = raw_name
-                    date: str = "-"
-                checkpoints.append(CheckpointTemplate(
-                    path=checkpoint_path,
-                    name=name,
-                    date=date,
-                    persistent=True
-                ))
+            checkpoints: list[CheckpointTemplate] = [checkpoint for checkpoint in CheckpointManager.checkpoints() if checkpoint.name.startswith(CheckpointManager.usermade_checkpoint_prefix)]
+
             if len(checkpoints) == 0:
                 self.io.output(f"No checkpoints were yet created, create one via {Color.Brightblue.value}checkpoint <name>{Color.Reset.value}.")
                 return CommandHandlerResult(undoable=False)
@@ -81,15 +38,15 @@ class CheckpointHandler(CommandHandler):
                 indent_size: int = longest_index_size + len(separator) + longest_date_size + len(separator)
                 indent: str = " " * indent_size
 
+                display_name: str = checkpoint.name.removeprefix(CheckpointManager.usermade_checkpoint_prefix)
                 wrapped_name: str = wrap_text(
-                    text=checkpoint.name,
+                    text=display_name,
                     indent=indent,
                     omit_first_line_indent=True,
                     frame_wrap=True
                 )
 
-                is_temporary: bool = not checkpoint.persistent
-                if is_temporary:
+                if not checkpoint.persistent:
                     color: str = Color.Red.value if index % 2 == 1 else Color.Brightred.value
                 else:
                     color: str = Color.Brightblack.value if index % 2 == 1 else Color.Reset.value

--- a/work_tracker/command/commands/clear.py
+++ b/work_tracker/command/commands/clear.py
@@ -43,7 +43,7 @@ class ClearHandler(CommandHandler):
         date = date.fill_with_today().to_month_date()
         for day in date.days_in_a_month():
             self._handle_day(day)
-        self.data.month[date].fte = Config.command.fte.default_value
-        self.data.month[date].remote_work_ratio = Config.command.rwr.default_value
+        self.data.month[date].fte = Config.data.command.fte.default_value
+        self.data.month[date].remote_work_ratio = Config.data.command.rwr.default_value
         new_target_minutes_total: int = sum([480 * self.data.month[date].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in date.days_in_a_month()])
         self.data.month[date].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/clear.py
+++ b/work_tracker/command/commands/clear.py
@@ -1,6 +1,7 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling, DayType
+from work_tracker.config import Config
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
@@ -30,13 +31,19 @@ class ClearHandler(CommandHandler):
 
     def _handle_day(self, date: Date):
         date = date.fill_with_today().to_day_date()
-        self.data.day[date].reset(is_a_work_day=self.data.calendar.is_working_day(date.to_datetime()))
+        if self.data.calendar.is_working_day(date.to_datetime()):
+            day_type = DayType.WORKDAY
+        elif self.data.calendar.is_holiday(date.to_datetime()):
+            day_type = DayType.HOLIDAY
+        else:
+            day_type = DayType.WEEKEND
+        self.data.day[date].reset(day_type=day_type)
 
     def _handle_month(self, date: Date):
         date = date.fill_with_today().to_month_date()
         for day in date.days_in_a_month():
-            self.data.day[day].reset(is_a_work_day=self.data.calendar.is_working_day(day.to_datetime()))
-        self.data.month[date].fte = self.data.setup.default_fte
-        self.data.month[date].remote_work_ratio = self.data.setup.default_remote_work_ratio
-        new_target_minutes_total: int = sum([480 * self.data.month[date].fte if self.data.day[day].is_a_work_day else 0 for day in date.days_in_a_month()])
+            self._handle_day(day)
+        self.data.month[date].fte = Config.command.fte.default_value
+        self.data.month[date].remote_work_ratio = Config.command.rwr.default_value
+        new_target_minutes_total: int = sum([480 * self.data.month[date].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in date.days_in_a_month()])
         self.data.month[date].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/config.py
+++ b/work_tracker/command/commands/config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import yaml
 from pydantic import BaseModel
 
@@ -20,7 +22,7 @@ class ConfigHandler(CommandHandler):
             self.io.output("\n".join(text_with_lines))
             return CommandHandlerResult(undoable=False)
         elif date_count == 0 and argument_count == 1:
-            value: any = self._get_printable_nested_config_value(arguments[0])
+            value: Any = self._get_printable_nested_config_value(arguments[0])
             if value is None:
                 self.io.output(f"The field {Color.Brightblue.value}{arguments[0]}{Color.Reset.value} could not be found in the config.")
             else:
@@ -37,16 +39,16 @@ class ConfigHandler(CommandHandler):
         else: # argument_count > 2
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
-    def _get_config_value_via_dot_keys(self, value_path: str, use_clean_copy: bool) -> any:
+    def _get_config_value_via_dot_keys(self, value_path: str, use_clean_copy: bool) -> Any:
         keys: list[str] = value_path.split(".")
-        dictionary: dict[str, any] | any = Config.data.model_dump() if use_clean_copy else Config.data
+        dictionary: dict[str, Any] | Any = Config.data.model_dump() if use_clean_copy else Config.data
         for key in keys:
             if not isinstance(dictionary, BaseModel):
                 return None
             dictionary = getattr(dictionary, key)
         return dictionary
 
-    def _set_config_value_via_dot_keys(self, value_path: str, value: any) -> bool:
+    def _set_config_value_via_dot_keys(self, value_path: str, value: Any) -> bool:
         keys: list[str] = value_path.split(".")
         keys_before_last, last_key = keys[:-1], keys[-1]
         if last_key == "version":
@@ -76,8 +78,8 @@ class ConfigHandler(CommandHandler):
         Config.save()
         return True
 
-    def _get_printable_nested_config_value(self, value_path: str) -> any:
-        value: any = self._get_config_value_via_dot_keys(value_path, True)
+    def _get_printable_nested_config_value(self, value_path: str) -> Any:
+        value: Any = self._get_config_value_via_dot_keys(value_path, True)
         if value is None:
             return None
 

--- a/work_tracker/command/commands/config.py
+++ b/work_tracker/command/commands/config.py
@@ -55,21 +55,21 @@ class ConfigHandler(CommandHandler):
 
         dictionary: BaseModel | None = self._get_config_value_via_dot_keys(".".join(keys_before_last), False)
         if dictionary is None:
-            self.io.output(f"Could not find the specified field {Color.Brightred.value}{value_path}{Color.Reset.value}. Ensure that the path is correct.")
+            self.io.output(f"Could not find the specified field {Color.from_key(Config.data.output.error_color).value}{value_path}{Color.Reset.value}. Ensure that the path is correct.")
             return False
         elif not isinstance(dictionary, BaseModel):
-            self.io.output(f"The field {Color.Brightred.value}{value_path}{Color.Reset.value} could not be found in the config.")
+            self.io.output(f"The field {Color.from_key(Config.data.output.error_color).value}{value_path}{Color.Reset.value} could not be found in the config.")
             return False
         elif getattr(dictionary, last_key) is None:
-            self.io.output(f"The field {Color.Brightred.value}{value_path}{Color.Reset.value} could not be found in the config.")
+            self.io.output(f"The field {Color.from_key(Config.data.output.error_color).value}{value_path}{Color.Reset.value} could not be found in the config.")
             return False
         elif isinstance(getattr(dictionary, last_key), BaseModel):
-            self.io.output(f"The field {Color.Brightred.value}{value_path}{Color.Reset.value} is not a changeable config field.")
+            self.io.output(f"The field {Color.from_key(Config.data.output.error_color).value}{value_path}{Color.Reset.value} is not a changeable config field.")
             return False
 
         expected_type: type = type(getattr(dictionary, last_key)) # TODO this wont work if field can be assigned multiple types
         if not isinstance(value, expected_type):
-            self.io.output(f"Invalid type of value to change field {Color.Brightred.value}{last_key}{Color.Reset.value}.")
+            self.io.output(f"Invalid type of value to change field {Color.from_key(Config.data.output.error_color).value}{last_key}{Color.Reset.value}.")
             return False
 
         setattr(dictionary, last_key, value)

--- a/work_tracker/command/commands/config.py
+++ b/work_tracker/command/commands/config.py
@@ -39,13 +39,19 @@ class ConfigHandler(CommandHandler):
         else: # argument_count > 2
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
-    def _get_config_value_via_dot_keys(self, value_path: str, use_clean_copy: bool) -> Any:
+    def _get_config_value_via_dot_keys(self, value_path: str, get_dict_structure: bool) -> Any:
         keys: list[str] = value_path.split(".")
-        dictionary: dict[str, Any] | Any = Config.data.model_dump() if use_clean_copy else Config.data
+        dictionary: dict[str, Any] | Any = Config.data.model_dump() if get_dict_structure else Config.data
         for key in keys:
-            if not isinstance(dictionary, BaseModel):
+            if not get_dict_structure and not isinstance(dictionary, BaseModel):
                 return None
-            dictionary = getattr(dictionary, key)
+            elif get_dict_structure and not isinstance(dictionary, dict):
+                return None
+            
+            if get_dict_structure:
+                dictionary = dictionary.get(key)
+            else:
+                dictionary = getattr(dictionary, key)
         return dictionary
 
     def _set_config_value_via_dot_keys(self, value_path: str, value: Any) -> bool:

--- a/work_tracker/command/commands/config.py
+++ b/work_tracker/command/commands/config.py
@@ -12,7 +12,7 @@ from work_tracker.text.common import Color
 class ConfigHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 0:
-            yamllike_text: str = yaml.dump(Config.data.dict(), default_flow_style=False, sort_keys=False)
+            yamllike_text: str = yaml.dump(Config.data.model_dump(), default_flow_style=False, sort_keys=False)
             text_with_lines: list[str] = []
             for line in yamllike_text.splitlines():
                 text_with_lines.append(f"| {line}")
@@ -39,7 +39,7 @@ class ConfigHandler(CommandHandler):
 
     def _get_config_value_via_dot_keys(self, value_path: str, use_clean_copy: bool) -> any:
         keys: list[str] = value_path.split(".")
-        dictionary: dict[str, any] | any = Config.data.dict() if use_clean_copy else Config.data
+        dictionary: dict[str, any] | any = Config.data.model_dump() if use_clean_copy else Config.data
         for key in keys:
             if not isinstance(dictionary, BaseModel):
                 return None

--- a/work_tracker/command/commands/dayoff.py
+++ b/work_tracker/command/commands/dayoff.py
@@ -36,4 +36,4 @@ class DayoffHandler(CommandHandler):
         date = date.fill_with_today().to_month_date()
         for day in date.days_in_a_month():
             if self.data.day[day].day_type == DayType.WORKDAY:
-                self._handle_day(date)
+                self._handle_day(day)

--- a/work_tracker/command/commands/days.py
+++ b/work_tracker/command/commands/days.py
@@ -44,7 +44,7 @@ class DaysHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
             
         if date_count != 0:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_month_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
         else:
             match state.mode:

--- a/work_tracker/command/commands/days.py
+++ b/work_tracker/command/commands/days.py
@@ -13,10 +13,36 @@ class CalculateType(Enum):
     Remote = auto(),
 
 
+class CommandCallType(Enum):
+    MINUTES_ONLY = auto(),
+    CLEAN_MINUTES = auto(),
+    OFFICE_OR_REMOTE_MINUTES = auto(),
+    OFFICE_OR_REMOTE_CLEAN_MINUTES = auto(),
+
+
 class DaysHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        if argument_count == 0 or argument_count > 3:
+        call_type: CommandCallType = None
+        
+        if argument_count == 1:
+            call_type = CommandCallType.MINUTES_ONLY
+            if arguments[0].minutes <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="value bigger than 0"))
+        elif argument_count == 2 and isinstance(arguments[0], str) and isinstance(arguments[1], TimeArgument): # days ('office'|'remote') <minutes>
+            call_type = CommandCallType.OFFICE_OR_REMOTE_MINUTES
+            if arguments[1].minutes <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="value bigger than 0"))
+        elif argument_count == 2 and isinstance(arguments[0], TimeArgument) and isinstance(arguments[1], str): # days <minutes> ('clean')
+            call_type = CommandCallType.CLEAN_MINUTES
+            if arguments[0].minutes <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="value bigger than 0"))
+        elif argument_count == 3: # days ('office'|'remote') <minutes> ('clean')
+            call_type = CommandCallType.OFFICE_OR_REMOTE_CLEAN_MINUTES
+            if arguments[1].minutes <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="value bigger than 0"))
+        else: # argument_count == 0 or argument_count > 3
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+            
         if date_count != 0:
             if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
@@ -30,24 +56,25 @@ class DaysHandler(CommandHandler):
 
         for date in dates:
             date = date.fill_with(state.active_date)
-            if argument_count == 1:
-                self._execute(date, arguments[0].minutes, CalculateType.All, take_into_account_filled_dates=True)
-            elif argument_count == 2 and isinstance(arguments[0], str) and isinstance(arguments[1], TimeArgument): # minutes ('office'|'remote') <days>
-                if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
-                count_office_minutes: bool = "office".startswith(arguments[0])
-                self._execute(date, arguments[1].minutes, CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=True)
-            elif argument_count == 2 and isinstance(arguments[0], TimeArgument) and isinstance(arguments[1], str): # minutes <days> ('clean')
-                if not "clean".startswith(arguments[1]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="clean"))
-                self._execute(date, arguments[0].minutes, CalculateType.All, take_into_account_filled_dates=False)
-            elif argument_count == 3: # minutes ('office'|'remote') <days> ('clean')
-                if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
-                if not "clean".startswith(arguments[2]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="clean"))
-                count_office_minutes: bool = "office".startswith(arguments[0])
-                self._execute(date, arguments[1].minutes, CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=False)
+            match call_type:
+                case CommandCallType.MINUTES_ONLY:
+                    self._execute(date, arguments[0].minutes, CalculateType.All, take_into_account_filled_dates=True)
+                case CommandCallType.OFFICE_OR_REMOTE_MINUTES:
+                    if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
+                    count_office_minutes: bool = "office".startswith(arguments[0])
+                    self._execute(date, arguments[1].minutes, CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=True)
+                case CommandCallType.CLEAN_MINUTES:
+                    if not "clean".startswith(arguments[1]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="clean"))
+                    self._execute(date, arguments[0].minutes, CalculateType.All, take_into_account_filled_dates=False)
+                case CommandCallType.OFFICE_OR_REMOTE_CLEAN_MINUTES:
+                    if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
+                    if not "clean".startswith(arguments[2]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[2], expected_value="clean"))
+                    count_office_minutes: bool = "office".startswith(arguments[0])
+                    self._execute(date, arguments[1].minutes, CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=False)
         return CommandHandlerResult(undoable=False)
 
     def _execute(self, date: Date, target_minute_count: int, calculate_type: CalculateType, take_into_account_filled_dates: bool):

--- a/work_tracker/command/commands/days.py
+++ b/work_tracker/command/commands/days.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument, TimeArgument
-from work_tracker.common import Date, ReadonlyAppState, find_first_not_fulfilling, Mode, MonthData
+from work_tracker.common import Date, WorkLocation, ReadonlyAppState, find_first_not_fulfilling, Mode, MonthData
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidArgumentValue, CommandErrorInvalidDate, CommandErrorInvalidMode
 from work_tracker.text.common import about_symbol, Color
 
@@ -90,11 +90,11 @@ class DaysHandler(CommandHandler):
             case CalculateType.Office:
                 total_minutes = month.target_minutes * (1.0 - month.remote_work_ratio)
                 if take_into_account_filled_dates:
-                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].office_work)
+                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].work_location == WorkLocation.OFFICE)
             case CalculateType.Remote:
                 total_minutes = month.target_minutes * month.remote_work_ratio
                 if take_into_account_filled_dates:
-                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].remote_work)
+                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].work_location == WorkLocation.REMOTE)
 
         calculated_day_count: float = total_minutes / target_minute_count
         rounded_day_count: int = round(calculated_day_count)

--- a/work_tracker/command/commands/deletealias.py
+++ b/work_tracker/command/commands/deletealias.py
@@ -1,8 +1,8 @@
 from work_tracker.command.common import CommandArgument
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
+from work_tracker.error import CommandErrorInvalidArgumentCount
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.alias_manager import AliasManager
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, ReadonlyAppState
 
 
 class DeletealiasHandler(CommandHandler):

--- a/work_tracker/command/commands/deletealias.py
+++ b/work_tracker/command/commands/deletealias.py
@@ -1,0 +1,19 @@
+from work_tracker.command.common import CommandArgument
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
+from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
+from work_tracker.command.alias_manager import AliasManager
+from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+
+
+class DeletealiasHandler(CommandHandler):
+    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
+        if date_count == 0 and argument_count == 1:
+            alias_identifier: str = arguments[0]
+            if alias_identifier in AliasManager.aliases:
+                AliasManager.remove_alias(AliasManager.aliases[alias_identifier])
+                AliasManager.save_aliases_file()
+            else:
+                self.io.output("Unknown alias.") # TODO
+            return CommandHandlerResult(undoable=False)
+        else: # argument_count != 1
+            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))

--- a/work_tracker/command/commands/deletemacro.py
+++ b/work_tracker/command/commands/deletemacro.py
@@ -1,8 +1,8 @@
 from work_tracker.command.common import CommandArgument
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
+from work_tracker.error import CommandErrorInvalidArgumentCount
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.macro_manager import MacroManager
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, ReadonlyAppState
 
 
 class DeletemacroHandler(CommandHandler):

--- a/work_tracker/command/commands/end.py
+++ b/work_tracker/command/commands/end.py
@@ -2,8 +2,8 @@ import datetime
 
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument, TimeArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, Time, DayData
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidMode
+from work_tracker.common import Date, ReadonlyAppState, Mode, Time, DayData, find_first_not_fulfilling
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidMode, CommandErrorInvalidDate
 
 
 class EndHandler(CommandHandler):
@@ -15,13 +15,7 @@ class EndHandler(CommandHandler):
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
 
-            time_now: datetime.datetime = datetime.datetime.now()
-            day: DayData = self.data.day[state.active_date]
-            day.work_end = Time(
-                minutes_since_midnight=time_now.hour * 60 + time_now.minute
-            )
-            if day.work_start is not None:
-                day.minutes_at_work = day.work_end.minutes_since_midnight - day.work_start.minutes_since_midnight
+            self._handle_day(state.active_date)
             return CommandHandlerResult(undoable=True)
         elif date_count == 0 and argument_count == 1: # TODO handle if end time is before start time
             match state.mode:
@@ -30,13 +24,41 @@ class EndHandler(CommandHandler):
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
 
-            time: TimeArgument = arguments[0]
-            day: DayData = self.data.day[state.active_date]
-            day.work_end = Time(
+            self._handle_day(state.active_date, arguments[0])
+            return CommandHandlerResult(undoable=True)
+        elif date_count != 0 and argument_count == 0:
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
+            for date in dates:
+                self._handle_day(date.fill_with(state.active_date))
+            return CommandHandlerResult(undoable=True)
+        elif date_count != 0 and argument_count == 1:
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
+            for date in dates:
+                self._handle_day(date.fill_with(state.active_date), arguments[0])
+            return CommandHandlerResult(undoable=True)
+        else:  # argument_count > 1
+            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+
+    def _handle_day(self, date: Date, time: TimeArgument | None = None):
+        date = date.fill_with_today().to_day_date()
+        day: DayData = self.data.day[date]
+        if time is not None:
+            time_end: Time = Time(
                 minutes_since_midnight=time.minutes
             )
-            if day.work_start is not None:
-                day.minutes_at_work = day.work_end.minutes_since_midnight - day.work_start.minutes_since_midnight
-            return CommandHandlerResult(undoable=True)
-        else: # argument_count > 1
-            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+        else:
+            time_now: datetime.datetime = datetime.datetime.now()
+            time_end: Time = Time(
+                minutes_since_midnight=time_now.hour * 60 + time_now.minute
+            )
+        day.work_end = time_end
+
+        if day.work_start is not None and day.work_start.minutes_since_midnight > day.work_end.minutes_since_midnight:
+            day.work_start = time_end
+            day.minutes_at_work = 0
+        elif day.work_start is not None:
+            day.minutes_at_work = day.work_end.minutes_since_midnight - day.work_start.minutes_since_midnight
+
+        return CommandHandlerResult(undoable=True)

--- a/work_tracker/command/commands/exit.py
+++ b/work_tracker/command/commands/exit.py
@@ -1,5 +1,4 @@
 import sys
-import datetime
 
 from work_tracker.command.common import CommandArgument
 from work_tracker.error import CommandErrorInvalidArgumentCount

--- a/work_tracker/command/commands/exit.py
+++ b/work_tracker/command/commands/exit.py
@@ -14,7 +14,7 @@ class ExitHandler(CommandHandler):
             if state.mode != Mode.Today:
                 return CommandHandlerResult(undoable=False, change_active_date=Date.today())
             else:
-                CheckpointManager.save(datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S"), self.data)
+                CheckpointManager.save("exit", self.data, add_suffix_timestamp=True)
                 sys.exit()
         else: # argument_count != 0
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))

--- a/work_tracker/command/commands/fte.py
+++ b/work_tracker/command/commands/fte.py
@@ -2,7 +2,7 @@ from fractions import Fraction
 
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, DayType, ReadonlyAppState, Mode, find_first_not_fulfilling
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 from work_tracker.text.common import Color
 
@@ -44,5 +44,5 @@ class FteHandler(CommandHandler):
     def _change_fte(self, date: Date, fte: float):
         month: Date = date.fill_with_today().to_month_date()
         self.data.month[month].fte = fte
-        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in month.days_in_a_month()])
         self.data.month[month].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/help.py
+++ b/work_tracker/command/commands/help.py
@@ -22,9 +22,7 @@ class HelpHandler(CommandHandler):
                     frame_wrap=True
                 )
 
-                if command.name in ["block", "calculate", "info", "recalculate", "setup"]:
-                    color = Color.Red if index % 2 == 1 else Color.Brightred
-                elif index % 2 == 1:
+                if index % 2 == 1:
                     color = Color.Brightblack
                 else:
                     color = Color.Reset
@@ -33,7 +31,6 @@ class HelpHandler(CommandHandler):
             wrapped_text: str = "\n".join(descriptions)
             wrapped_footer_text: str = wrap_text(
                 text=(
-                    f" Commands not yet implemented are marked by {Color.Brightred.value}red{Color.Reset.value} color."
                     f"\nType {Color.Brightblue.value}help <command_name>{Color.Reset.value} to display detailed help description about a specific command."
                 ).strip(),
                 frame_wrap=True

--- a/work_tracker/command/commands/holiday.py
+++ b/work_tracker/command/commands/holiday.py
@@ -23,5 +23,15 @@ class HolidayHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
+        if self._is_current_month_target_from_fte(date.fill_with_today().to_month_date()):
+            self._update_month_target_minutes(date.fill_with_today().to_month_date())
+
         filled_date: Date = date.fill_with_today().to_day_date()
         self.data.day[filled_date].is_a_work_day = False
+
+    def _is_current_month_target_from_fte(self, month: Date) -> bool:
+        return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+
+    def _update_month_target_minutes(self, month: Date):
+        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        self.data.month[month].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/holiday.py
+++ b/work_tracker/command/commands/holiday.py
@@ -1,6 +1,6 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, DayType, ReadonlyAppState, Mode, find_first_not_fulfilling
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
@@ -30,14 +30,14 @@ class HolidayHandler(CommandHandler):
         if self._is_current_month_target_from_fte(month_date):
             update_target_minutes = True
 
-        self.data.day[day_date].is_a_work_day = False
+        self.data.day[day_date].day_type = DayType.HOLIDAY
 
         if update_target_minutes:
             self._update_month_target_minutes(month_date)
 
     def _is_current_month_target_from_fte(self, month: Date) -> bool:
-        return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in month.days_in_a_month()])
 
     def _update_month_target_minutes(self, month: Date):
-        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in month.days_in_a_month()])
         self.data.month[month].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/holiday.py
+++ b/work_tracker/command/commands/holiday.py
@@ -23,11 +23,17 @@ class HolidayHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
-        if self._is_current_month_target_from_fte(date.fill_with_today().to_month_date()):
-            self._update_month_target_minutes(date.fill_with_today().to_month_date())
+        day_date: Date = date.fill_with_today().to_day_date()
+        month_date: Date = date.fill_with_today().to_month_date()
+        update_target_minutes = False
 
-        filled_date: Date = date.fill_with_today().to_day_date()
-        self.data.day[filled_date].is_a_work_day = False
+        if self._is_current_month_target_from_fte(month_date):
+            update_target_minutes = True
+
+        self.data.day[day_date].is_a_work_day = False
+
+        if update_target_minutes:
+            self._update_month_target_minutes(month_date)
 
     def _is_current_month_target_from_fte(self, month: Date) -> bool:
         return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])

--- a/work_tracker/command/commands/info.py
+++ b/work_tracker/command/commands/info.py
@@ -1,9 +1,136 @@
+import calendar as cal
+from fractions import Fraction
+
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState
-from work_tracker.error import CommandErrorNotImplemented
+from work_tracker.common import Date, DayData, Mode, MonthData, ReadonlyAppState, DayType, WorkLocation, AttendanceType, find_first_not_fulfilling
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate
+from work_tracker.text.common import Color, frame_text
 
 
 class InfoHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        return CommandHandlerResult(undoable=False, error=CommandErrorNotImplemented(command_name=self.command_name))
+        if date_count == 0 and argument_count == 0:
+            match state.mode:
+                case Mode.Today | Mode.Day:
+                    self._handle_day(state.active_date)
+                case Mode.Month:
+                    self._handle_month(state.active_date)
+                case _:
+                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
+            return CommandHandlerResult(undoable=False)
+        elif date_count != 0 and argument_count == 0:
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
+            for date in dates:
+                if date.is_day_date():
+                    self._handle_day(date.fill_with(state.active_date))
+                elif date.is_month_date():
+                    self._handle_month(date.fill_with(state.active_date))
+            return CommandHandlerResult(undoable=False)
+        else: # argument_count != 0
+            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+
+    @staticmethod
+    def _format_minutes(minutes: int) -> str: # TODO: move to a common file ?
+        hours: int = int(minutes // 60)
+        mins: int = int(minutes % 60)
+        return f"{hours}:{mins:02}"
+
+    @staticmethod
+    def _format_time(minutes_since_midnight: int) -> str: # TODO: move to a common file ?
+        hours: int = minutes_since_midnight // 60
+        mins: int = minutes_since_midnight % 60
+        return f"{hours}:{mins:02}"
+
+    def _handle_day(self, date: Date):
+        filled_date: Date = date.fill_with_today().to_day_date()
+        day_data: DayData = self.data.day[filled_date]
+
+        attendance_map: dict[AttendanceType, str] = {
+            AttendanceType.PRESENT: "present",
+            AttendanceType.DAYOFF: "day off",
+            AttendanceType.ABSENCE: "absence",
+        }
+        day_type_map: dict[DayType, str] = {
+            DayType.WORKDAY: "workday",
+            DayType.WEEKEND: "weekend",
+            DayType.HOLIDAY: "holiday",
+        }
+        location_map: dict[WorkLocation, str] = {
+            WorkLocation.UNSPECIFIED: "unspecified",
+            WorkLocation.REMOTE: "remote",
+            WorkLocation.OFFICE: "office",
+        }
+
+        rows: list[tuple[str, str]] = [
+            ("attendance", attendance_map.get(day_data.attendance_type, "unknown")),
+            ("day type", day_type_map.get(day_data.day_type, "unknown")),
+            ("work location", location_map.get(day_data.work_location, "unknown")),
+            ("time at work", self._format_minutes(day_data.minutes_at_work)),
+            ("target time", self._format_minutes(day_data.target_minutes)),
+        ]
+        if day_data.work_start is not None:
+            rows.append(("work start", self._format_time(day_data.work_start.minutes_since_midnight)))
+        if day_data.work_end is not None:
+            rows.append(("work end", self._format_time(day_data.work_end.minutes_since_midnight)))
+        
+        longest_label: int = max(len(label) for label, _ in rows)
+        separator: str = " | "
+        lines: list[str] = [
+            f"{Color.Brightblack.value if index % 2 == 1 else Color.Reset.value}{label.rjust(longest_label)}{separator}{Color.Brightcyan.value}{value}"
+            for index, (label, value) in enumerate(rows)
+        ]
+
+        title: str = f"{filled_date.day:02}.{filled_date.month:02}.{filled_date.year}"
+        framed_text: str = frame_text(text="\n".join(lines), title=title, title_color=Color.Bold)
+        self.io.output(framed_text)
+
+    def _handle_month(self, date: Date):
+        filled_date: Date = date.fill_with_today().to_month_date()
+        month_data: MonthData = self.data.month[filled_date]
+
+        fte_text: str = "full-time" if month_data.fte == 1.0 else Fraction(month_data.fte).limit_denominator().__str__()
+
+        if month_data.remote_work_ratio == 0:
+            rwr_text: str = "office only"
+        elif month_data.remote_work_ratio == 1:
+            rwr_text: str = "remote only"
+        else:
+            rwr_text: str = Fraction(month_data.remote_work_ratio).limit_denominator().__str__()
+
+        target_minutes_total: int = month_data.target_minutes
+        target_minutes_office: int = int(target_minutes_total * (1.0 - month_data.remote_work_ratio))
+        target_minutes_remote: int = int(target_minutes_total * month_data.remote_work_ratio)
+
+        days_in_month: list[Date] = filled_date.days_in_a_month()
+        working_days: int = sum(1 for day in days_in_month if self.data.day[day].day_type == DayType.WORKDAY)
+        office_days: int = sum(1 for day in days_in_month if self.data.day[day].work_location == WorkLocation.OFFICE)
+        remote_days: int = sum(1 for day in days_in_month if self.data.day[day].work_location == WorkLocation.REMOTE)
+        absent_days: int = sum(1 for day in days_in_month if self.data.day[day].attendance_type == AttendanceType.ABSENCE)
+        day_offs: int = sum(1 for day in days_in_month if self.data.day[day].attendance_type == AttendanceType.DAYOFF)
+
+        rows: list[tuple[str, str]] = [
+            ("fte", fte_text),
+            ("remote work ratio", rwr_text),
+            ("target time", self._format_minutes(target_minutes_total)),
+            ("target office time", self._format_minutes(target_minutes_office)),
+            ("target remote time", self._format_minutes(target_minutes_remote)),
+            ("working days", str(working_days)),
+            ("office days", str(office_days)),
+            ("remote days", str(remote_days)),
+            ("absent days", str(absent_days)),
+            ("day offs", str(day_offs)),
+        ]
+
+        longest_label: int = max(len(label) for label, _ in rows)
+        separator: str = " | "
+        lines: list[str] = [
+            f"{Color.Brightblack.value if index % 2 == 1 else Color.Reset.value}{label.rjust(longest_label)}{separator}{Color.Brightcyan.value}{value}"
+            for index, (label, value) in enumerate(rows)
+        ]
+
+        month_name: str = cal.month_name[filled_date.month]
+        title: str = f"{month_name} {filled_date.year}"
+        framed_text: str = frame_text(text="\n".join(lines), title=title, title_color=Color.Bold)
+        self.io.output(framed_text)

--- a/work_tracker/command/commands/info.py
+++ b/work_tracker/command/commands/info.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import Date, DayData, Mode, MonthData, ReadonlyAppState, DayType, WorkLocation, AttendanceType, find_first_not_fulfilling
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 from work_tracker.text.common import Color, frame_text
 
 

--- a/work_tracker/command/commands/key.py
+++ b/work_tracker/command/commands/key.py
@@ -12,7 +12,7 @@ class KeyHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 0:
             self.io.output(
-                text="Generated keys can be quite long. Do you want to copy it into a clipboard instead of displaying it in a terminal?",
+                text="Generated keys can be thousands of characters long. Do you want to copy it into a clipboard instead of displaying it in a terminal?",
                 color=Color.Brightred,
             )
             while True:

--- a/work_tracker/command/commands/keyword.py
+++ b/work_tracker/command/commands/keyword.py
@@ -46,7 +46,7 @@ class KeywordHandler(CommandHandler):
 
             color: str = Color.Brightblack.value if index % 2 == 1 else Color.Reset.value
             keyword_texts.append(
-                f"{color}{identifier_padded}{Color.Reset.value}{separator}{modes_text}{separator}{Color.Brightcyan.value}{example_value_padded}{Color.Reset.value}{separator}{color}{wrapped_description}"
+                f"{color}{identifier_padded}{color}{separator}{modes_text}{color}{separator}{Color.Brightcyan.value}{example_value_padded}{color}{separator}{wrapped_description}"
             )
         
         wrapped_text: str = "\n".join(keyword_texts)

--- a/work_tracker/command/commands/keyword.py
+++ b/work_tracker/command/commands/keyword.py
@@ -1,0 +1,77 @@
+from work_tracker.config import Config
+from work_tracker.error import CommandErrorInvalidDateCount, CommandErrorInvalidArgumentCount
+from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
+from work_tracker.command.common import CommandArgument
+from work_tracker.command.keyword_manager import KeywordManager, KeywordTemplate
+from work_tracker.common import Date, Mode, ReadonlyAppState
+from work_tracker.text.common import wrap_text, frame_text, Color, strip_ansi
+
+
+class KeywordHandler(CommandHandler):
+    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
+        if date_count != 0:
+            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))
+        
+        if argument_count != 0:
+            return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+        
+        keywords: list[KeywordTemplate] = KeywordManager.iterable_keywords
+        longest_identifier_size: int = max(len(keyword.identifier) for keyword in keywords)
+        
+        example_values: dict[str, str] = {keyword.identifier: f"{KeywordManager.get_keyword_value(keyword.identifier, state)}" for keyword in keywords}
+        longest_example_value_size: int = max(len(example_values[keyword.identifier]) for keyword in keywords)
+        
+        separator: str = " | " # TODO make separator configurable
+        keyword_texts: list[str] = []
+        
+        modes: list[Mode] = [Mode.Today, Mode.Day, Mode.Month] # explicit list to define custom order of values
+        modes_text_length: int = len(" ".join([mode.name[0].upper() for mode in modes]))
+        
+        for index, keyword in enumerate(keywords):
+            identifier_padded: str = keyword.identifier.ljust(longest_identifier_size)
+            modes_text: str = " ".join([f"{(Color.Green if mode in keyword.supported_modes else Color.Red).value}{mode.name[0].upper()}{Color.Reset.value}" for mode in modes])
+            
+            example_value: str = example_values[keyword.identifier]
+            example_value_padded: str = example_value.ljust(longest_example_value_size)
+            
+            indent_size: int = longest_identifier_size + len(separator) + modes_text_length + len(separator) + longest_example_value_size + len(separator)
+            indent: str = " " * indent_size
+            
+            wrapped_description: str = wrap_text(
+                text=keyword.description,
+                indent=indent,
+                omit_first_line_indent=True,
+                frame_wrap=True
+            )
+
+            color: str = Color.Brightblack.value if index % 2 == 1 else Color.Reset.value
+            keyword_texts.append(
+                f"{color}{identifier_padded}{Color.Reset.value}{separator}{modes_text}{separator}{Color.Brightcyan.value}{example_value_padded}{Color.Reset.value}{separator}{color}{wrapped_description}"
+            )
+        
+        wrapped_text: str = "\n".join(keyword_texts)
+        
+        prefix: str = Config.data.input.keyword_prefix
+        footer_text: str = wrap_text(
+            text=f"To use keywords type its name with a prefix: {Color.Brightblue.value}{prefix}{Color.Reset.value}, for example: {Color.Brightblue.value}{prefix}today{Color.Reset.value}. Prefix can be changed via the config command.",
+            frame_wrap=True
+        )
+        
+        longest_line_width: int = max([len(strip_ansi(line)) for line in wrapped_text.splitlines()] + [len(strip_ansi(line)) for line in footer_text.splitlines()])
+        
+        framed_text: str = frame_text(
+            text=wrapped_text,
+            title="Built-in Keywords",
+            title_color=Color.Bold,
+            skip_bottom_line=True,
+            minimal_line_width=longest_line_width
+        )
+        framed_footer_text: str = frame_text(
+            text=footer_text,
+            extend_top_line=True,
+            minimal_line_width=longest_line_width
+        )
+        
+        self.io.write(framed_text)
+        self.io.output(framed_footer_text)
+        return CommandHandlerResult(undoable=False)

--- a/work_tracker/command/commands/keyword.py
+++ b/work_tracker/command/commands/keyword.py
@@ -53,7 +53,8 @@ class KeywordHandler(CommandHandler):
         
         prefix: str = Config.data.input.keyword_prefix
         footer_text: str = wrap_text(
-            text=f"To use keywords type its name with a prefix: {Color.Brightblue.value}{prefix}{Color.Reset.value}, for example: {Color.Brightblue.value}{prefix}today{Color.Reset.value}. Prefix can be changed via the config command.",
+            text=f"To use keywords type its name with a prefix: {Color.Brightblue.value}{prefix}{Color.Reset.value}, for example: {Color.Brightblue.value}{prefix}today{Color.Reset.value}. "
+                 f"Prefix can be changed via the {Color.Brightblue.value}config{Color.Reset.value} command.",
             frame_wrap=True
         )
         

--- a/work_tracker/command/commands/macro.py
+++ b/work_tracker/command/commands/macro.py
@@ -61,12 +61,12 @@ class MacroHandler(CommandHandler):
             command_text: str = " ".join(arguments_to_process[command_text_starts_at:])
 
             # TODO check if macro_identifier is equal to an existing command or its abbreviation
-            default_values: list[any] = [] # TODO duplicated code via MacroManager
+            default_values: list[str|None] = [] # TODO duplicated code via MacroManager
             parsed_arguments: list[str] = []
             for argument in macro_arguments:
                 if "=" in argument: # TODO arguments with '=' must be after arguments without it
                     name, value = argument[1:-1].split("=", 1)
-                    default_values.append(value)
+                    default_values.append('') if value.lower() == "null" else default_values.append(value)
                     parsed_arguments.append(f"{name}")
                 else:
                     default_values.append(None)

--- a/work_tracker/command/commands/macro.py
+++ b/work_tracker/command/commands/macro.py
@@ -20,16 +20,16 @@ class MacroHandler(CommandHandler):
 
             # TODO add ellipsis here and in other places modifiable by user (custom methods in the future)
             # TODO what if definition is very long => solution: set max length in config and add ellipsis if its too long
-            seperator: str = " | " # TODO make seperator configurable, but the read logic must be changed too
+            separator: str = " | " # TODO make separator configurable, but the read logic must be changed too
             macro_texts: list[str] = []
             for index, (definition, command) in enumerate(zip(macro_definitions, macro_commands)):
                 command_wrapped: str = wrap_text(
                     text=command,
-                    indent=" "*(longest_definition_size + len(seperator)),
+                    indent=" "*(longest_definition_size + len(separator)),
                     omit_first_line_indent=True,
                     frame_wrap=True
                 )
-                macro_texts.append(f"{Color.Brightblack.value if index % 2 == 1 else Color.Reset.value}{definition.rjust(longest_definition_size)}{seperator}{command_wrapped}")
+                macro_texts.append(f"{Color.Brightblack.value if index % 2 == 1 else Color.Reset.value}{definition.rjust(longest_definition_size)}{separator}{command_wrapped}")
 
             framed_text: str = frame_text(
                 text="\n".join(macro_texts),

--- a/work_tracker/command/commands/minutes.py
+++ b/work_tracker/command/commands/minutes.py
@@ -44,7 +44,7 @@ class MinutesHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
         
         if date_count != 0:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_month_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
         else:
             match state.mode:

--- a/work_tracker/command/commands/minutes.py
+++ b/work_tracker/command/commands/minutes.py
@@ -106,7 +106,7 @@ class MinutesHandler(CommandHandler):
             self.io.write(f"{about_symbol if not is_exact_minute_count else ''}{rounded_total_minutes_per_day} minutes", color=Color.Brightblue, end=" ")
         else:
             self.io.write(f"{about_symbol if not is_exact_minute_count else ''}{hours}:{minutes:02}", color=Color.Brightblue, end=" ")
-        self.io.write(f"each day", end=" ")
+        self.io.write("each day", end=" ")
         self.io.write(f"({Color.Brightblue.value}{day_count}{Color.Reset.value} times)", end="")
         match calculate_type:
             case CalculateType.Office:

--- a/work_tracker/command/commands/minutes.py
+++ b/work_tracker/command/commands/minutes.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, find_first_not_fulfilling, Mode, MonthData
+from work_tracker.common import Date, WorkLocation, ReadonlyAppState, find_first_not_fulfilling, Mode, MonthData
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidArgumentValue, CommandErrorInvalidDate, CommandErrorInvalidMode
 from work_tracker.text.common import about_symbol, Color
 
@@ -90,11 +90,11 @@ class MinutesHandler(CommandHandler):
             case CalculateType.Office:
                 total_minutes = month.target_minutes * (1.0 - month.remote_work_ratio)
                 if take_into_account_filled_dates:
-                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].office_work)
+                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].work_location == WorkLocation.OFFICE)
             case CalculateType.Remote:
                 total_minutes = month.target_minutes * month.remote_work_ratio
                 if take_into_account_filled_dates:
-                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].remote_work)
+                    total_minutes -= sum(self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].work_location == WorkLocation.REMOTE)
         
         total_minutes_per_day: float = total_minutes / day_count
         rounded_total_minutes_per_day: int = round(total_minutes_per_day)

--- a/work_tracker/command/commands/minutes.py
+++ b/work_tracker/command/commands/minutes.py
@@ -13,10 +13,36 @@ class CalculateType(Enum):
     Remote = auto(),
 
 
+class CommandCallType(Enum):
+    DAYS_ONLY = auto(),
+    CLEAN_DAYS = auto(),
+    OFFICE_OR_REMOTE_DAYS = auto(),
+    OFFICE_OR_REMOTE_CLEAN_DAYS = auto(),
+
+
 class MinutesHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        if argument_count == 0 or argument_count > 3:
+        call_type: CommandCallType = None
+        
+        if argument_count == 1:
+            call_type = CommandCallType.DAYS_ONLY
+            if arguments[0] <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="value bigger than 0"))
+        elif argument_count == 2 and isinstance(arguments[0], str) and isinstance(arguments[1], int): # minutes ('office'|'remote') <days>
+            call_type = CommandCallType.OFFICE_OR_REMOTE_DAYS
+            if arguments[1] <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="value bigger than 0"))
+        elif argument_count == 2 and isinstance(arguments[0], int) and isinstance(arguments[1], str): # minutes <days> ('clean')
+            call_type = CommandCallType.CLEAN_DAYS
+            if arguments[0] <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="value bigger than 0"))
+        elif argument_count == 3: # minutes ('office'|'remote') <days> ('clean')
+            call_type = CommandCallType.OFFICE_OR_REMOTE_CLEAN_DAYS
+            if arguments[1] <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="value bigger than 0"))
+        else: # argument_count == 0 or argument_count > 3
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+        
         if date_count != 0:
             if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
@@ -30,24 +56,25 @@ class MinutesHandler(CommandHandler):
 
         for date in dates:
             date = date.fill_with(state.active_date)
-            if argument_count == 1:
-                self._execute(date, arguments[0], CalculateType.All, take_into_account_filled_dates=True)
-            elif argument_count == 2 and isinstance(arguments[0], str)  and isinstance(arguments[1], int): # minutes ('office'|'remote') <days>
-                if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
-                count_office_minutes: bool = "office".startswith(arguments[0])
-                self._execute(date, arguments[1], CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=True)
-            elif argument_count == 2 and isinstance(arguments[0], int) and isinstance(arguments[1], str): # minutes <days> ('clean')
-                if not "clean".startswith(arguments[1]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="clean"))
-                self._execute(date, arguments[0], CalculateType.All, take_into_account_filled_dates=False)
-            elif argument_count == 3: # minutes ('office'|'remote') <days> ('clean')
-                if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
-                if not "clean".startswith(arguments[2]):
-                    return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value="clean"))
-                count_office_minutes: bool = "office".startswith(arguments[0])
-                self._execute(date, arguments[1], CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=False)
+            match call_type:
+                case CommandCallType.DAYS_ONLY:
+                    self._execute(date, arguments[0], CalculateType.All, take_into_account_filled_dates=True)
+                case CommandCallType.OFFICE_OR_REMOTE_DAYS:
+                    if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
+                    count_office_minutes: bool = "office".startswith(arguments[0])
+                    self._execute(date, arguments[1], CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=True)
+                case CommandCallType.CLEAN_DAYS:
+                    if not "clean".startswith(arguments[1]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[1], expected_value="clean"))
+                    self._execute(date, arguments[0], CalculateType.All, take_into_account_filled_dates=False)
+                case CommandCallType.OFFICE_OR_REMOTE_CLEAN_DAYS:
+                    if not "office".startswith(arguments[0]) and not "remote".startswith(arguments[0]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=["office", "remote"]))
+                    if not "clean".startswith(arguments[2]):
+                        return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[2], expected_value="clean"))
+                    count_office_minutes: bool = "office".startswith(arguments[0])
+                    self._execute(date, arguments[1], CalculateType.Office if count_office_minutes else CalculateType.Remote, take_into_account_filled_dates=False)
         return CommandHandlerResult(undoable=False)
             
     def _execute(self, date: Date, day_count: int, calculate_type: CalculateType, take_into_account_filled_dates: bool):

--- a/work_tracker/command/commands/office.py
+++ b/work_tracker/command/commands/office.py
@@ -1,6 +1,6 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, DayType, WorkLocation, ReadonlyAppState, Mode, find_first_not_fulfilling
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
@@ -10,20 +10,29 @@ class OfficeHandler(CommandHandler):
             match state.mode:
                 case Mode.Today | Mode.Day:
                     self._handle_day(state.active_date)
-                    return CommandHandlerResult(undoable=True)
+                case Mode.Month:
+                    self._handle_month(state.active_date)
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
+            return CommandHandlerResult(undoable=True)
         elif date_count != 0 and argument_count == 0:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
             for date in dates:
-                self._handle_day(date.fill_with(state.active_date))
+                if date.is_day_date():
+                    self._handle_day(date.fill_with(state.active_date))
+                elif date.is_month_date():
+                    self._handle_month(date.fill_with(state.active_date))
             return CommandHandlerResult(undoable=True)
         else: # argument_count != 0
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
         filled_date: Date = date.fill_with_today().to_day_date()
-        self.data.day[filled_date].office_work = True
-        self.data.day[filled_date].remote_work = False
-        self.data.day[date].is_a_day_off = False
+        self.data.day[filled_date].work_location = WorkLocation.OFFICE
+
+    def _handle_month(self, date: Date):
+        date = date.fill_with_today().to_month_date()
+        for day in date.days_in_a_month():
+            if self.data.day[day].day_type == DayType.WORKDAY:
+                self._handle_day(day)

--- a/work_tracker/command/commands/office.py
+++ b/work_tracker/command/commands/office.py
@@ -26,3 +26,4 @@ class OfficeHandler(CommandHandler):
         filled_date: Date = date.fill_with_today().to_day_date()
         self.data.day[filled_date].office_work = True
         self.data.day[filled_date].remote_work = False
+        self.data.day[date].is_a_day_off = False

--- a/work_tracker/command/commands/present.py
+++ b/work_tracker/command/commands/present.py
@@ -4,7 +4,7 @@ from work_tracker.common import Date, AttendanceType, DayType, ReadonlyAppState,
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
-class DayoffHandler(CommandHandler):
+class PresentHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 0:
             match state.mode:
@@ -18,7 +18,6 @@ class DayoffHandler(CommandHandler):
         elif date_count != 0 and argument_count == 0:
             if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
-                
             for date in dates:
                 if date.is_day_date():
                     self._handle_day(date.fill_with(state.active_date))
@@ -29,8 +28,8 @@ class DayoffHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
-        date = date.fill_with_today().to_day_date()
-        self.data.day[date].attendance_type = AttendanceType.DAYOFF
+        filled_date: Date = date.fill_with_today().to_day_date()
+        self.data.day[filled_date].attendance_type = AttendanceType.PRESENT
 
     def _handle_month(self, date: Date):
         date = date.fill_with_today().to_month_date()

--- a/work_tracker/command/commands/present.py
+++ b/work_tracker/command/commands/present.py
@@ -35,4 +35,4 @@ class PresentHandler(CommandHandler):
         date = date.fill_with_today().to_month_date()
         for day in date.days_in_a_month():
             if self.data.day[day].day_type == DayType.WORKDAY:
-                self._handle_day(date)
+                self._handle_day(day)

--- a/work_tracker/command/commands/recalculate.py
+++ b/work_tracker/command/commands/recalculate.py
@@ -1,9 +1,0 @@
-from work_tracker.command.common import CommandArgument
-from work_tracker.error import CommandErrorNotImplemented
-from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
-from work_tracker.common import Date, ReadonlyAppState
-
-
-class RecalculateHandler(CommandHandler):
-    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        return CommandHandlerResult(undoable=False, error=CommandErrorNotImplemented(command_name=self.command_name))

--- a/work_tracker/command/commands/redo.py
+++ b/work_tracker/command/commands/redo.py
@@ -1,12 +1,16 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import Date, ReadonlyAppState
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDateCount
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidArgumentValue, CommandErrorInvalidDateCount
 
 
 class RedoHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        if date_count == 0 and argument_count == 0:
+        if date_count == 0 and argument_count <= 1:
+            count: int = arguments[0] if argument_count == 1 else 1
+            if count <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=str(count), expected_value="a positive integer"))
+
             index: int = state.current_state_index
             history_size: int = len(state.states)
             if history_size == 0:
@@ -15,8 +19,11 @@ class RedoHandler(CommandHandler):
             elif index == history_size-1:
                 self.io.output("No more commands left to redo.")
                 return CommandHandlerResult(undoable=False)
-            return CommandHandlerResult(undoable=False, change_state_by=1)
+
+            max_steps: int = history_size - 1 - index
+            steps: int = min(count, max_steps)
+            return CommandHandlerResult(undoable=False, change_state_by=steps)
         elif date_count != 0:
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))
-        else: # argument_count != 0
+        else: # argument_count > 1
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))

--- a/work_tracker/command/commands/remote.py
+++ b/work_tracker/command/commands/remote.py
@@ -26,3 +26,4 @@ class RemoteHandler(CommandHandler):
         filled_date: Date = date.fill_with_today().to_day_date()
         self.data.day[filled_date].remote_work = True
         self.data.day[filled_date].office_work = False
+        self.data.day[date].is_a_day_off = False

--- a/work_tracker/command/commands/remote.py
+++ b/work_tracker/command/commands/remote.py
@@ -1,6 +1,6 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, DayType, WorkLocation, ReadonlyAppState, Mode, find_first_not_fulfilling
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
@@ -10,20 +10,29 @@ class RemoteHandler(CommandHandler):
             match state.mode:
                 case Mode.Today | Mode.Day:
                     self._handle_day(state.active_date)
-                    return CommandHandlerResult(undoable=True)
+                case Mode.Month:
+                    self._handle_month(state.active_date)
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
+            return CommandHandlerResult(undoable=True)
         elif date_count != 0 and argument_count == 0:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
             for date in dates:
-                self._handle_day(date.fill_with(state.active_date))
+                if date.is_day_date():
+                    self._handle_day(date.fill_with(state.active_date))
+                elif date.is_month_date():
+                    self._handle_month(date.fill_with(state.active_date))
             return CommandHandlerResult(undoable=True)
         else: # argument_count != 0
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
         filled_date: Date = date.fill_with_today().to_day_date()
-        self.data.day[filled_date].remote_work = True
-        self.data.day[filled_date].office_work = False
-        self.data.day[date].is_a_day_off = False
+        self.data.day[filled_date].work_location = WorkLocation.REMOTE
+
+    def _handle_month(self, date: Date):
+        date = date.fill_with_today().to_month_date()
+        for day in date.days_in_a_month():
+            if self.data.day[day].day_type == DayType.WORKDAY:
+                self._handle_day(day)

--- a/work_tracker/command/commands/rollback.py
+++ b/work_tracker/command/commands/rollback.py
@@ -1,21 +1,135 @@
-from work_tracker.checkpoint_manager import CheckpointManager
+import datetime
+import os
+
+from work_tracker.checkpoint_manager import CheckpointManager, CheckpointTemplate
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
-from work_tracker.command.common import CommandArgument
+from work_tracker.command.common import CommandArgument, AdditionalInputArgument
 from work_tracker.common import Date, ReadonlyAppState, AppData
+from work_tracker.config import Config
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDateCount
+from work_tracker.text.common import Color, wrap_text, frame_text, strip_ansi
 
 
 class RollbackHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
         if date_count == 0 and argument_count == 1 and isinstance(arguments[0], str):
             checkpoint_identifier: str = arguments[0]
-            data: AppData = CheckpointManager.load(f"user.{checkpoint_identifier}") # TODO hardcoded 'user.'
-            if data is None:
+            matches: list[CheckpointTemplate] = self._find_checkpoint_by_name(checkpoint_identifier)
+
+            if len(matches) == 0:
                 self.io.output(f"Could not find a checkpoint named {checkpoint_identifier}.")
                 return CommandHandlerResult(undoable=False)
-            self.data.copy_from(data)
-            return CommandHandlerResult(undoable=True)
+            elif len(matches) == 1:
+                return self._load_checkpoint(matches[0])
+            else:
+                return self._prompt_selection(matches, checkpoint_identifier)
+
         elif date_count != 0:
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))
-        else: # argument_count != 0
+        else: # argument_count != 1
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+
+    def _find_checkpoint_by_name(self, name: str) -> list[CheckpointTemplate]:
+        matches: list[CheckpointTemplate] = []
+
+        for checkpoint in CheckpointManager.checkpoints():
+            if not checkpoint.name.startswith(CheckpointManager.usermade_checkpoint_prefix):
+                continue
+
+            checkpoint_name: str = checkpoint.name.removeprefix(CheckpointManager.usermade_checkpoint_prefix)
+            if checkpoint_name == name:
+                matches.append(checkpoint)
+
+        return sorted(matches, key=lambda m: os.path.getctime(m.path))
+
+    def _load_checkpoint(self, checkpoint: CheckpointTemplate) -> CommandHandlerResult:
+        data: AppData = CheckpointManager.load(
+            checkpoint.full_identifier,
+            persistent_checkpoint=checkpoint.persistent
+        )
+        if data is None:
+            self.io.output(f"Failed to load checkpoint {checkpoint.name}.")
+            return CommandHandlerResult(undoable=False)
+        self.data.copy_from(data)
+        return CommandHandlerResult(undoable=True)
+
+    def _display_found_checkpoints(self, matches: list[CheckpointTemplate], checkpoint_identifier: str):
+        formatted_dates: list[str] = [
+            match.date if match.date == "-" else datetime.datetime.strptime(match.date, "%Y-%m-%d_%H-%M-%S").strftime("%d-%m-%Y %H:%M:%S")
+            for match in matches
+        ]
+
+        longest_index_size: int = len(str(len(matches)))
+        longest_date_size: int = max((len(date) for date in formatted_dates), default=0)
+        separator: str = " | "
+
+        lines: list[str] = []
+        for index, match in enumerate(matches):
+            index_padded: str = str(index + 1).ljust(longest_index_size)
+            date_padded: str = formatted_dates[index].ljust(longest_date_size)
+            type_: str = "temporary" if not match.persistent else "permanent"
+            if not match.persistent:
+                color: str = Color.Red.value if index % 2 == 1 else Color.Brightred.value
+            else:
+                color: str = Color.Brightblack.value if index % 2 == 1 else Color.Reset.value
+
+            indent_size: int = longest_index_size + len(separator) + longest_date_size + len(separator)
+            indent: str = " " * indent_size
+
+            wrapped_type: str = wrap_text(
+                text=type_,
+                indent=indent,
+                omit_first_line_indent=True,
+                frame_wrap=True
+            )
+            lines.append(f"{color}{index_padded}{separator}{date_padded}{separator}{wrapped_type}{Color.Reset.value}")
+
+        text: str = "\n".join(lines)
+
+        footer_text: str = wrap_text(
+            text=(
+                f"Found {len(matches)} checkpoints named {Color.Brightblue.value}{checkpoint_identifier}{Color.Reset.value}."
+                f" Type a checkpoint's number to load it or type {Color.Brightblue.value}quit{Color.Reset.value} to cancel."
+            ),
+            frame_wrap=True
+        )
+
+        text_lines_len: list[int] = [len(strip_ansi(line)) for line in text.splitlines()]
+        footer_lines_len: list[int] = [len(strip_ansi(line)) for line in footer_text.splitlines()]
+        longest_line_width: int = max(text_lines_len + footer_lines_len, default=0)
+
+        framed_text: str = frame_text(
+            text=text,
+            title="Matching checkpoints",
+            title_color=Color.Bold,
+            skip_bottom_line=True,
+            minimal_line_width=longest_line_width
+        )
+        framed_footer: str = frame_text(
+            text=footer_text,
+            extend_top_line=True,
+            minimal_line_width=longest_line_width
+        )
+
+        self.io.write(framed_text)
+        self.io.output(framed_footer)
+
+    def _prompt_selection(self, matches: list[CheckpointTemplate], checkpoint_identifier: str) -> CommandHandlerResult:
+        valid_indices: list[str] = [str(i + 1) for i in range(len(matches))]
+
+        while True:
+            self._display_found_checkpoints(matches, checkpoint_identifier)
+            user_input: list[AdditionalInputArgument] = self.get_additional_input(custom_autocomplete=valid_indices + ["quit"])
+            if len(user_input) != 1:
+                continue
+
+            if isinstance(user_input[0], int) and 1 <= user_input[0] <= len(matches):
+                return self._load_checkpoint(matches[user_input[0]-1])
+            elif isinstance(user_input[0], str):
+                word: str = user_input[0].lower()
+                if "quit".startswith(word):
+                    return CommandHandlerResult(undoable=False)
+                else:
+                    self.io.output("Unknown command.", color=Color.from_key(Config.data.output.error_color))
+            else:
+                self.io.output("Please enter a valid checkpoint number.", color=Color.from_key(Config.data.output.error_color))

--- a/work_tracker/command/commands/rollback.py
+++ b/work_tracker/command/commands/rollback.py
@@ -7,9 +7,9 @@ from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInv
 
 class RollbackHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        if date_count == 0 and argument_count == 1:
+        if date_count == 0 and argument_count == 1 and isinstance(arguments[0], str):
             checkpoint_identifier: str = arguments[0]
-            data: AppData = CheckpointManager.load(checkpoint_identifier, manual_checkpoint=True)
+            data: AppData = CheckpointManager.load(f"user.{checkpoint_identifier}") # TODO hardcoded 'user.'
             if data is None:
                 self.io.output(f"Could not find a checkpoint named {checkpoint_identifier}.")
                 return CommandHandlerResult(undoable=False)

--- a/work_tracker/command/commands/rwr.py
+++ b/work_tracker/command/commands/rwr.py
@@ -3,7 +3,7 @@ from fractions import Fraction
 from work_tracker.command.common import CommandArgument
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, DayType, ReadonlyAppState, Mode, find_first_not_fulfilling
 from work_tracker.text.common import Color
 
 
@@ -46,5 +46,5 @@ class RwrHandler(CommandHandler):
     def _change_rwr(self, date: Date, rwr: float):
         month: Date = date.fill_with_today().to_month_date()
         self.data.month[month].remote_work_ratio = rwr
-        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in month.days_in_a_month()])
         self.data.month[month].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/rwr.py
+++ b/work_tracker/command/commands/rwr.py
@@ -14,19 +14,19 @@ class RwrHandler(CommandHandler):
             return CommandHandlerResult(undoable=False)
         elif date_count == 0 and argument_count == 1:
             match state.mode:
-                case Mode.Today | Mode.Month:
+                case Mode.Today | Mode.Day | Mode.Month:
                     self._change_rwr(state.active_date, arguments[0])
                     return CommandHandlerResult(undoable=True)
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
         elif date_count != 0 and argument_count == 0:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_month_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
             for date in dates:
                 self._output_rwr(date.fill_with(state.active_date))
             return CommandHandlerResult(undoable=False)
         elif date_count != 0 and argument_count == 1:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_month_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
             for date in dates:
                 self._change_rwr(date.fill_with(state.active_date), arguments[0])

--- a/work_tracker/command/commands/setup.py
+++ b/work_tracker/command/commands/setup.py
@@ -1,9 +1,0 @@
-from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
-from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState
-from work_tracker.error import CommandErrorNotImplemented
-
-
-class SetupHandler(CommandHandler):
-    def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        return CommandHandlerResult(undoable=False, error=CommandErrorNotImplemented(command_name=self.command_name))

--- a/work_tracker/command/commands/start.py
+++ b/work_tracker/command/commands/start.py
@@ -2,8 +2,8 @@ import datetime
 
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument, TimeArgument
-from work_tracker.common import Date, ReadonlyAppState, DayData, Time, Mode
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidMode, CommandErrorInvalidDateCount
+from work_tracker.common import Date, ReadonlyAppState, DayData, Time, Mode, find_first_not_fulfilling
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidMode, CommandErrorInvalidDate
 
 
 class StartHandler(CommandHandler):
@@ -15,13 +15,7 @@ class StartHandler(CommandHandler):
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
 
-            time_now: datetime.datetime = datetime.datetime.now()
-            day: DayData = self.data.day[state.active_date]
-            day.work_start = Time(
-                minutes_since_midnight=time_now.hour * 60 + time_now.minute
-            )
-            if day.work_end is not None:
-                day.minutes_at_work = day.work_end.minutes_since_midnight - day.work_start.minutes_since_midnight
+            self._handle_day(state.active_date)
             return CommandHandlerResult(undoable=True)
         elif date_count == 0 and argument_count == 1: # TODO handle if end time is before start time
             match state.mode:
@@ -30,13 +24,41 @@ class StartHandler(CommandHandler):
                 case _:
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
 
-            time: TimeArgument = arguments[0]
-            day: DayData = self.data.day[state.active_date]
-            day.work_start = Time(
-                minutes_since_midnight=time.minutes
-            )
-            if day.work_end is not None:
-                day.minutes_at_work = day.work_end.minutes_since_midnight - day.work_start.minutes_since_midnight
+            self._handle_day(state.active_date, arguments[0])
+            return CommandHandlerResult(undoable=True)
+        elif date_count != 0 and argument_count == 0:
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
+            for date in dates:
+                self._handle_day(date.fill_with(state.active_date))
+            return CommandHandlerResult(undoable=True)
+        elif date_count != 0 and argument_count == 1:
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
+            for date in dates:
+                self._handle_day(date.fill_with(state.active_date), arguments[0])
             return CommandHandlerResult(undoable=True)
         else: # argument_count > 1
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
+
+    def _handle_day(self, date: Date, time: TimeArgument | None = None):
+        date = date.fill_with_today().to_day_date()
+        day: DayData = self.data.day[date]
+        if time is not None:
+            time_start: Time = Time(
+                minutes_since_midnight=time.minutes
+            )
+        else:
+            time_now: datetime.datetime = datetime.datetime.now()
+            time_start: Time = Time(
+                minutes_since_midnight=time_now.hour * 60 + time_now.minute
+            )
+        day.work_start = time_start
+
+        if day.work_end is not None and day.work_start.minutes_since_midnight > day.work_end.minutes_since_midnight:
+            day.work_end = time_start
+            day.minutes_at_work = 0
+        elif day.work_end is not None:
+            day.minutes_at_work = day.work_end.minutes_since_midnight - day.work_start.minutes_since_midnight
+
+        return CommandHandlerResult(undoable=True)

--- a/work_tracker/command/commands/status.py
+++ b/work_tracker/command/commands/status.py
@@ -40,12 +40,12 @@ class StatusHandler(CommandHandler):
         minutes: int = int(minutes_at_work % 60)
         target_hours: int = int(target_minutes // 60)
         target_minutes: int = int(target_minutes % 60)
-        if target_hours == 0:
+        if target_hours == 0 and hours == 0:
             self.io.write(f"{minutes} minutes", color=Color.Brightblue, end=" ")
         else:
             self.io.write(f"{hours}:{minutes:02}", color=Color.Brightblue, end="")
         self.io.write("/", end="")
-        if target_hours == 0:
+        if target_hours == 0 and hours == 0:
             self.io.output(f" {target_minutes} minutes", color=Color.Blue)
         else:
             self.io.output(f"{target_hours}:{target_minutes:02}", color=Color.Blue)
@@ -65,12 +65,12 @@ class StatusHandler(CommandHandler):
             target_hours: int = int(target_minutes_office // 60)
             target_minutes: int = int(target_minutes_office % 60)
 
-            if target_hours == 0:
+            if target_hours == 0 and hours == 0:
                 self.io.write(f"{minutes} minutes", color=Color.Brightblue, end=" ")
             else:
                 self.io.write(f"{hours}:{minutes:02}", color=Color.Brightblue, end="")
             self.io.write("/", end="")
-            if target_hours == 0:
+            if target_hours == 0 and hours == 0:
                 self.io.write(f" {target_minutes} minutes", color=Color.Blue, end=" ")
             else:
                 self.io.write(f"{target_hours}:{target_minutes:02}", color=Color.Blue, end=" ")
@@ -80,12 +80,12 @@ class StatusHandler(CommandHandler):
             minutes: int = int(minutes_at_work_remote % 60)
             target_hours: int = int(target_minutes_remote // 60)
             target_minutes: int = int(target_minutes_remote % 60)
-            if target_hours == 0:
+            if target_hours == 0 and hours == 0:
                 self.io.write(f"{minutes} minutes", color=Color.Brightblue, end=" ")
             else:
                 self.io.write(f"{hours}:{minutes:02}", color=Color.Brightblue, end="")
             self.io.write("/", end="")
-            if target_hours == 0:
+            if target_hours == 0 and hours == 0:
                 self.io.write(f" {target_minutes} minutes", color=Color.Blue, end=" ")
             else:
                 self.io.write(f"{target_hours}:{target_minutes:02}", color=Color.Blue, end=" ")

--- a/work_tracker/command/commands/status.py
+++ b/work_tracker/command/commands/status.py
@@ -1,6 +1,6 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, ReadonlyAppState, Mode, find_first_not_fulfilling
+from work_tracker.common import Date, WorkLocation, ReadonlyAppState, Mode, find_first_not_fulfilling
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode, CommandErrorInvalidDateCount
 from work_tracker.text.common import Color
 
@@ -52,8 +52,8 @@ class StatusHandler(CommandHandler):
 
     def _handle_month(self, date: Date):
         date = date.fill_with_today().to_day_date()
-        minutes_at_work_office: int = sum([self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].office_work])
-        minutes_at_work_remote: int = sum([self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].remote_work])
+        minutes_at_work_office: int = sum([self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].work_location == WorkLocation.OFFICE])
+        minutes_at_work_remote: int = sum([self.data.day[day].minutes_at_work for day in date.days_in_a_month() if self.data.day[day].work_location == WorkLocation.REMOTE])
         month: Date = date.to_month_date()
         target_minutes_total: int = self.data.month[month].target_minutes
         target_minutes_office: int = int(target_minutes_total * (1.0 - self.data.month[month].remote_work_ratio))

--- a/work_tracker/command/commands/tutorial.py
+++ b/work_tracker/command/commands/tutorial.py
@@ -1,70 +1,73 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument, AdditionalInputArgument
-from work_tracker.common import Date, ReadonlyAppState
+from work_tracker.common import Date, ReadonlyAppState, classproperty
 from work_tracker.config import Config
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidArgumentValue, CommandErrorInvalidDateCount
 from work_tracker.text.common import wrap_text, frame_text, Color, strip_ansi
 
 
 class TutorialHandler(CommandHandler):
-    pages: list[str] = [
-        (
-            f" {Color.Brightblue.value}WorkTracker{Color.Reset.value} operates within the context of an active date, which, by default, is set to today’s date."
-            f" To change the active date, simply specify a target date. The active date can be set to a particular day or an entire month."
-            
-            f"\n\nTo switch to a different date, enter it in the {Color.Brightblue.value}DD.MM.YYYY{Color.Reset.value} format."
-            f" If you choose not to provide the complete date, the missing portions will be automatically filled in using the currently active date."
-            f" This means that formats {Color.Brightblue.value}DD.{Color.Reset.value}, {Color.Brightblue.value}.MM.{Color.Reset.value},"
-            f" {Color.Brightblue.value}DD.MM{Color.Reset.value}, and {Color.Brightblue.value}.MM.YYYY{Color.Reset.value} are also supported."
-            f" Additionally, you can switch to month mode by entering either the full name of the month or its three-letter abbreviation."
-            # f" (e.g. {Color.BRIGHT_BLUE.value}jul{Color.RESET.value} for July or {Color.BRIGHT_BLUE.value}dec{Color.RESET.value} for December)."
-        ).strip(),
-        (
-            f"\n\nThe active date determines {Color.Brightblue.value}WorkTracker{Color.Reset.value}'s operational mode,"
-            f" which can be set to {Color.Brightblue.value}today{Color.Reset.value}, {Color.Brightblue.value}day{Color.Reset.value} or {Color.Brightblue.value}month{Color.Reset.value}."
-            f" Please note that certain commands may behave differently or may not be available depending on the active mode."
-            
-            f"\n\nEach command can also be assigned a specific date on which it should execute by placing the date before the command"
-            f" (e.g. {Color.Brightblue.value}24.02 status{Color.Reset.value})."
-            f" Furthermore, commands can accept multiple dates. If dates are enclosed in {Color.Brightblue.value}(){Color.Reset.value}, they will be applied to all commands in the sequence."
-            
-            f"\n\nCommands can be chained together using the {Color.Brightblue.value}{Config.data.input.command_chain_symbol}{Color.Reset.value} symbol, with execution proceeding from left to right."
-            f" Lastly, commands can be abbreviated to the shortest unique string that distinctly identifies them."
-            f" for example, the {Color.Brightblue.value}tutorial{Color.Reset.value} command can be executed simply by typing {Color.Brightblue.value}tu{Color.Reset.value}."
-        ).strip(),
-        (
-            f" To record time spent at work for the currently active date, simply input the time in {Color.Brightblue.value}HH:MM{Color.Reset.value} format"
-            f" or use descriptive terms such as {Color.Brightblue.value}50 minutes{Color.Reset.value} or {Color.Brightblue.value}2h{Color.Reset.value}."
-            f" Additionally, you can add or subtract time from the current total by prefixing the time with {Color.Brightblue.value}+{Color.Reset.value} or {Color.Brightblue.value}-{Color.Reset.value}."
-            
-            f"\n\nTo view the total time spent working on the active date, you can use the {Color.Brightblue.value}status{Color.Reset.value} command"
-            f" which will also display the target work time."
-        ).strip(),
-        (
-            f" By default, {Color.Brightblue.value}WorkTracker{Color.Reset.value} assumes that you work full-time and have 40% remote work ratio."
-            f" You can change the default settings to better reflect your work schedule and preferences via the {Color.Brightblue.value}config{Color.Reset.value} command."
-            f" You can adjust the Full-Time Equivalent (FTE) for the current month by using the {Color.Brightblue.value}fte{Color.Reset.value} command."
-            f" Additionally, the {Color.Brightblue.value}rwr{Color.Reset.value} command allows you to modify the required remote work ratio."
-            f" Both of these commands are applicable in the month context."
-            
-            f"\n\nThe {Color.Brightblue.value}calendar{Color.Reset.value} command provides a calendar view with marked days, highlighting  weekends, holidays, office or remote workdays and any off-days or absences."
-            f" You can manually designate specific dates as holidays, workdays, off-days, absences and office or remote workdays using the"
-            f" {Color.Brightblue.value}holiday{Color.Reset.value}, {Color.Brightblue.value}workday{Color.Reset.value}, {Color.Brightblue.value}offday{Color.Reset.value},"
-            f" {Color.Brightblue.value}absence{Color.Reset.value}, {Color.Brightblue.value}office{Color.Reset.value} and {Color.Brightblue.value}remote{Color.Reset.value} commands, respectively."
-        ).strip(),
-        (
-            f" The {Color.Brightblue.value}minutes{Color.Reset.value} and {Color.Brightblue.value}days{Color.Reset.value}"
-            f" commands allow you to calculate the remaining number of days or the time left to meet your monthly work quota."
-            f" {Color.Brightblue.value}WorkTracker{Color.Reset.value} also offers several additional useful commands,"
-            f" such as creating macros with the {Color.Brightblue.value}macro{Color.Reset.value} command,"
-            f" configuring aliases with the {Color.Brightblue.value}alias{Color.Reset.value} command,"
-            f" setting up checkpoints with the {Color.Brightblue.value}checkpoint{Color.Reset.value} command,"
-            f" and adjusting {Color.Brightblue.value}WorkTracker{Color.Reset.value}'s behavior via the {Color.Brightblue.value}config{Color.Reset.value} command."
-            
-            f"\n\nFor detailed information about any command, please use the {Color.Brightblue.value}help{Color.Reset.value} command."
-            f" If you encounter any issues, feel free to report them directly to me, and enjoy using {Color.Brightblue.value}WorkTracker{Color.Reset.value}!"
-        ).strip(),
-    ]
+    @classproperty
+    def pages(self) -> list[str]:
+        return [
+            (
+                f" {Color.Brightblue.value}WorkTracker{Color.Reset.value} operates within the context of an active date, which, by default, is set to today’s date."
+                f" To change the active date, simply specify a target date. The active date can be set to a particular day or an entire month."
+                
+                f"\n\nTo switch to a different date, enter it in the {Color.Brightblue.value}DD.MM.YYYY{Color.Reset.value} format."
+                f" If you choose not to provide the complete date, the missing portions will be automatically filled in using the currently active date."
+                f" This means that formats {Color.Brightblue.value}DD.{Color.Reset.value}, {Color.Brightblue.value}.MM.{Color.Reset.value},"
+                f" {Color.Brightblue.value}DD.MM{Color.Reset.value}, and {Color.Brightblue.value}.MM.YYYY{Color.Reset.value} are also supported."
+                f" Additionally, you can switch to month mode by entering either the full name of the month or its three-letter abbreviation."
+                # f" (e.g. {Color.BRIGHT_BLUE.value}jul{Color.RESET.value} for July or {Color.BRIGHT_BLUE.value}dec{Color.RESET.value} for December)."
+            ).strip(),
+            (
+                f"\n\nThe active date determines {Color.Brightblue.value}WorkTracker{Color.Reset.value}'s operational mode,"
+                f" which can be set to {Color.Brightblue.value}today{Color.Reset.value}, {Color.Brightblue.value}day{Color.Reset.value} or {Color.Brightblue.value}month{Color.Reset.value}."
+                f" Please note that certain commands may behave differently or may not be available depending on the active mode."
+                
+                f"\n\nEach command can also be assigned a specific date on which it should execute by placing the date before the command"
+                f" (e.g. {Color.Brightblue.value}24.02 status{Color.Reset.value})."
+                f" Furthermore, commands can accept multiple dates. If dates are enclosed in {Color.Brightblue.value}(){Color.Reset.value}, they will be applied to all commands in the sequence."
+                
+                f"\n\nCommands can be chained together using the {Color.Brightblue.value}{Config.data.input.command_chain_symbol}{Color.Reset.value} symbol, with execution proceeding from left to right."
+                f" Lastly, commands can be abbreviated to the shortest unique string that distinctly identifies them."
+                f" for example, the {Color.Brightblue.value}tutorial{Color.Reset.value} command can be executed simply by typing {Color.Brightblue.value}tu{Color.Reset.value}."
+            ).strip(),
+            (
+                f" To record time spent at work for the currently active date, simply input the time in {Color.Brightblue.value}HH:MM{Color.Reset.value} format"
+                f" or use descriptive terms such as {Color.Brightblue.value}50 minutes{Color.Reset.value} or {Color.Brightblue.value}2h{Color.Reset.value}."
+                f" Additionally, you can add or subtract time from the current total by prefixing the time with {Color.Brightblue.value}+{Color.Reset.value} or {Color.Brightblue.value}-{Color.Reset.value}."
+                
+                f"\n\nTo view the total time spent working on the active date, you can use the {Color.Brightblue.value}status{Color.Reset.value} command"
+                f" which will also display the target work time."
+            ).strip(),
+            (
+                f" By default, {Color.Brightblue.value}WorkTracker{Color.Reset.value} assumes that you work full-time and have 40% remote work ratio."
+                f" You can change the default settings to better reflect your work schedule and preferences via the {Color.Brightblue.value}config{Color.Reset.value} command."
+                f" You can adjust the Full-Time Equivalent (FTE) for the current month by using the {Color.Brightblue.value}fte{Color.Reset.value} command."
+                f" Additionally, the {Color.Brightblue.value}rwr{Color.Reset.value} command allows you to modify the required remote work ratio."
+                f" Both of these commands are applicable in the month context."
+                
+                f"\n\nThe {Color.Brightblue.value}calendar{Color.Reset.value} command provides a calendar view with marked days, highlighting  weekends, holidays, office or remote workdays and any off-days or absences."
+                f" You can manually designate specific dates as holidays, workdays, off-days, absences and office or remote workdays using the"
+                f" {Color.Brightblue.value}holiday{Color.Reset.value}, {Color.Brightblue.value}workday{Color.Reset.value}, {Color.Brightblue.value}offday{Color.Reset.value},"
+                f" {Color.Brightblue.value}absence{Color.Reset.value}, {Color.Brightblue.value}office{Color.Reset.value} and {Color.Brightblue.value}remote{Color.Reset.value} commands, respectively."
+            ).strip(),
+            (
+                f" The {Color.Brightblue.value}minutes{Color.Reset.value} and {Color.Brightblue.value}days{Color.Reset.value}"
+                f" commands allow you to calculate the remaining number of days or the time left to meet your monthly work quota."
+                f" {Color.Brightblue.value}WorkTracker{Color.Reset.value} also offers several additional useful commands,"
+                f" such as creating macros with the {Color.Brightblue.value}macro{Color.Reset.value} command,"
+                f" configuring aliases with the {Color.Brightblue.value}alias{Color.Reset.value} command,"
+                f" setting up checkpoints with the {Color.Brightblue.value}checkpoint{Color.Reset.value} command,"
+                f" and adjusting {Color.Brightblue.value}WorkTracker{Color.Reset.value}'s behavior via the {Color.Brightblue.value}config{Color.Reset.value} command."
+                
+                f"\n\nFor detailed information about any command, please use the {Color.Brightblue.value}help{Color.Reset.value} command."
+                f" If you encounter any issues, feel free to report them directly to me, and enjoy using {Color.Brightblue.value}WorkTracker{Color.Reset.value}!"
+            ).strip(),
+        ]
+
     footer_text: str = f"You can change active page by typing target page's number or by typing {Color.Brightblue.value}next{Color.Reset.value} or {Color.Brightblue.value}previous{Color.Reset.value}. To leave write {Color.Brightblue.value}quit{Color.Reset.value}."
 
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:

--- a/work_tracker/command/commands/tutorial.py
+++ b/work_tracker/command/commands/tutorial.py
@@ -42,24 +42,22 @@ class TutorialHandler(CommandHandler):
         ).strip(),
         (
             f" By default, {Color.Brightblue.value}WorkTracker{Color.Reset.value} assumes that you work full-time and have 40% remote work ratio."
+            f" You can change the default settings to better reflect your work schedule and preferences via the {Color.Brightblue.value}config{Color.Reset.value} command."
             f" You can adjust the Full-Time Equivalent (FTE) for the current month by using the {Color.Brightblue.value}fte{Color.Reset.value} command."
             f" Additionally, the {Color.Brightblue.value}rwr{Color.Reset.value} command allows you to modify the required remote work ratio."
             f" Both of these commands are applicable in the month context."
             
-            f"\n\nThe {Color.Brightblue.value}calendar{Color.Reset.value} command provides a calendar view with marked days, highlighting  weekends, holidays, office or remote workdays and any off-days."
-            f" You can manually designate specific dates as holidays, workdays, off-days and office or remote workdays using the"
+            f"\n\nThe {Color.Brightblue.value}calendar{Color.Reset.value} command provides a calendar view with marked days, highlighting  weekends, holidays, office or remote workdays and any off-days or absences."
+            f" You can manually designate specific dates as holidays, workdays, off-days, absences and office or remote workdays using the"
             f" {Color.Brightblue.value}holiday{Color.Reset.value}, {Color.Brightblue.value}workday{Color.Reset.value}, {Color.Brightblue.value}offday{Color.Reset.value},"
-            f" {Color.Brightblue.value}office{Color.Reset.value} and {Color.Brightblue.value}remote{Color.Reset.value} commands, respectively."
-            
-            f"\n\nCurrently, until the {Color.Brightblue.value}setup{Color.Reset.value}, {Color.Brightblue.value}calculate{Color.Reset.value} and {Color.Brightblue.value}recalculate{Color.Reset.value}"
-            f" commands are implemented, you will need to manually enter your work schedule for each month."
-            f" These upcoming features will automatically generate a suggested schedule and allocate the required amount of time to be spent working each day."
+            f" {Color.Brightblue.value}absence{Color.Reset.value}, {Color.Brightblue.value}office{Color.Reset.value} and {Color.Brightblue.value}remote{Color.Reset.value} commands, respectively."
         ).strip(),
         (
             f" The {Color.Brightblue.value}minutes{Color.Reset.value} and {Color.Brightblue.value}days{Color.Reset.value}"
             f" commands allow you to calculate the remaining number of days or the time left to meet your monthly work quota."
             f" {Color.Brightblue.value}WorkTracker{Color.Reset.value} also offers several additional useful commands,"
             f" such as creating macros with the {Color.Brightblue.value}macro{Color.Reset.value} command,"
+            f" configuring aliases with the {Color.Brightblue.value}alias{Color.Reset.value} command,"
             f" setting up checkpoints with the {Color.Brightblue.value}checkpoint{Color.Reset.value} command,"
             f" and adjusting {Color.Brightblue.value}WorkTracker{Color.Reset.value}'s behavior via the {Color.Brightblue.value}config{Color.Reset.value} command."
             

--- a/work_tracker/command/commands/tutorial.py
+++ b/work_tracker/command/commands/tutorial.py
@@ -93,7 +93,7 @@ class TutorialHandler(CommandHandler):
                     elif "previous".startswith(word):
                         current_page_index = max(0, current_page_index-1)
                     else:
-                        self.io.output("Unknown command.", color=Color.Brightred)
+                        self.io.output("Unknown command.", color=Color.from_key(Config.data.output.error_color))
 
             return CommandHandlerResult(undoable=False)
         elif date_count == 0 and argument_count == 1:

--- a/work_tracker/command/commands/tutorial.py
+++ b/work_tracker/command/commands/tutorial.py
@@ -75,7 +75,7 @@ class TutorialHandler(CommandHandler):
             total_pages: int = len(self.pages)
 
             while True:
-                self.display_page_(current_page_index)
+                self.display_page(current_page_index)
                 user_input: list[AdditionalInputArgument] = self.get_additional_input(custom_autocomplete=[str(number+1) for number in range(total_pages)] + ["next", "previous", "quit"])
                 if len(user_input) != 1:
                     continue
@@ -99,14 +99,14 @@ class TutorialHandler(CommandHandler):
         elif date_count == 0 and argument_count == 1:
             if arguments[0] <= 0 or arguments[0] >= len(self.pages):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=arguments[0], expected_value=f"page number between 1 and {len(self.pages)}"))
-            self.display_page_(arguments[0]-1)
+            self.display_page(arguments[0]-1)
             return CommandHandlerResult(undoable=False)
         elif date_count != 0:
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))
         else: # argument_count > 1
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
-    def display_page_(self, index: int):
+    def display_page(self, index: int):
         wrapped_page_text: str = wrap_text(
             text=self.pages[index],
             width=Config.data.output.max_width,

--- a/work_tracker/command/commands/undo.py
+++ b/work_tracker/command/commands/undo.py
@@ -1,12 +1,16 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
 from work_tracker.common import Date, ReadonlyAppState
-from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDateCount
+from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidArgumentValue, CommandErrorInvalidDateCount
 
 
 class UndoHandler(CommandHandler):
     def handle(self, dates: list[Date], date_count: int, arguments: list[CommandArgument], argument_count: int, state: ReadonlyAppState) -> CommandHandlerResult:
-        if date_count == 0 and argument_count == 0:
+        if date_count == 0 and argument_count <= 1:
+            count: int = arguments[0] if argument_count == 1 else 1
+            if count <= 0:
+                return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentValue(self.command_name, received_value=str(count), expected_value="a positive integer"))
+
             index: int = state.current_state_index
             history_size: int = len(state.states)
             if history_size == 0:
@@ -15,8 +19,10 @@ class UndoHandler(CommandHandler):
             elif index == 0:
                 self.io.output("No more commands left to undo.")
                 return CommandHandlerResult(undoable=False)
-            return CommandHandlerResult(undoable=False, change_state_by=-1)
+
+            steps: int = min(count, index)
+            return CommandHandlerResult(undoable=False, change_state_by=-steps)
         elif date_count != 0:
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))
-        else: # argument_count != 0
+        else: # argument_count > 1
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))

--- a/work_tracker/command/commands/version.py
+++ b/work_tracker/command/commands/version.py
@@ -15,7 +15,3 @@ class VersionHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDateCount(self.command_name, received_date_count=date_count, expected_date_count=0))
         else: # argument_count != 0
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
-
-    def _handle_day(self, date: Date):
-        filled_date: Date = date.fill_with_today().to_day_date()
-        self.data.day[filled_date].is_a_work_day = True

--- a/work_tracker/command/commands/workday.py
+++ b/work_tracker/command/commands/workday.py
@@ -23,11 +23,17 @@ class WorkdayHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
-        if self._is_current_month_target_from_fte(date.fill_with_today().to_month_date()):
-            self._update_month_target_minutes(date.fill_with_today().to_month_date())
+        day_date: Date = date.fill_with_today().to_day_date()
+        month_date: Date = date.fill_with_today().to_month_date()
+        update_target_minutes = False
 
-        filled_date: Date = date.fill_with_today().to_day_date()
-        self.data.day[filled_date].is_a_work_day = True
+        if self._is_current_month_target_from_fte(month_date):
+            update_target_minutes = True
+
+        self.data.day[day_date].is_a_work_day = True
+
+        if update_target_minutes:
+            self._update_month_target_minutes(month_date)
 
     def _is_current_month_target_from_fte(self, month: Date) -> bool:
         return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])

--- a/work_tracker/command/commands/workday.py
+++ b/work_tracker/command/commands/workday.py
@@ -1,6 +1,6 @@
 from work_tracker.command.command_handler import CommandHandlerResult, CommandHandler
 from work_tracker.command.common import CommandArgument
-from work_tracker.common import Date, Mode, find_first_not_fulfilling, ReadonlyAppState
+from work_tracker.common import Date, DayType, Mode, find_first_not_fulfilling, ReadonlyAppState
 from work_tracker.error import CommandErrorInvalidArgumentCount, CommandErrorInvalidDate, CommandErrorInvalidMode
 
 
@@ -30,14 +30,14 @@ class WorkdayHandler(CommandHandler):
         if self._is_current_month_target_from_fte(month_date):
             update_target_minutes = True
 
-        self.data.day[day_date].is_a_work_day = True
+        self.data.day[day_date].day_type = DayType.WORKDAY
 
         if update_target_minutes:
             self._update_month_target_minutes(month_date)
 
     def _is_current_month_target_from_fte(self, month: Date) -> bool:
-        return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in month.days_in_a_month()])
 
     def _update_month_target_minutes(self, month: Date):
-        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].day_type == DayType.WORKDAY else 0 for day in month.days_in_a_month()])
         self.data.month[month].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/workday.py
+++ b/work_tracker/command/commands/workday.py
@@ -23,5 +23,15 @@ class WorkdayHandler(CommandHandler):
             return CommandHandlerResult(undoable=False, error=CommandErrorInvalidArgumentCount(self.command_name, received_argument_count=argument_count))
 
     def _handle_day(self, date: Date):
+        if self._is_current_month_target_from_fte(date.fill_with_today().to_month_date()):
+            self._update_month_target_minutes(date.fill_with_today().to_month_date())
+
         filled_date: Date = date.fill_with_today().to_day_date()
         self.data.day[filled_date].is_a_work_day = True
+
+    def _is_current_month_target_from_fte(self, month: Date) -> bool:
+        return self.data.month[month].target_minutes == sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+
+    def _update_month_target_minutes(self, month: Date):
+        new_target_minutes_total: int = sum([480 * self.data.month[month].fte if self.data.day[day].is_a_work_day else 0 for day in month.days_in_a_month()])
+        self.data.month[month].target_minutes = new_target_minutes_total

--- a/work_tracker/command/commands/zero.py
+++ b/work_tracker/command/commands/zero.py
@@ -16,7 +16,7 @@ class ZeroHandler(CommandHandler):
                     return CommandHandlerResult(undoable=False, error=CommandErrorInvalidMode(self.command_name, mode=state.mode))
             return CommandHandlerResult(undoable=True)
         elif date_count != 0 and argument_count == 0:
-            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date()):
+            if invalid_date := find_first_not_fulfilling(dates, lambda date: date.is_day_date() or date.is_month_date()):
                 return CommandHandlerResult(undoable=False, error=CommandErrorInvalidDate(self.command_name, received_date=invalid_date))
             for date in dates:
                 if date.is_day_date():

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -231,9 +231,9 @@ _global_command_templates: list[CommandTemplate] = [
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "days <minutes>", "calculates the number of days required to reach the monthly target work time while keeping daily work time as close as possible to the given amount"),
-                CommandUseCaseDescription(set(Mode), "days ['office'|'remote'] <minutes>", "calculates the required number of days, limited to remote or office work"),
+                CommandUseCaseDescription(set(Mode), "days <'office'|'remote'> <minutes>", "calculates the required number of days, limited to remote or office work"),
                 CommandUseCaseDescription(set(Mode), "days <minutes> 'clean'", "calculates the required number of days, ignoring already logged work time in a month"),
-                CommandUseCaseDescription(set(Mode), "days ['office'|'remote'] <minutes> 'clean'", "calculates the required number of days, limited to remote or office work, while ignoring already logged work time in a month"),
+                CommandUseCaseDescription(set(Mode), "days <'office'|'remote'> <minutes> 'clean'", "calculates the required number of days, limited to remote or office work, while ignoring already logged work time in a month"),
             ],
         ),
         supported_modes=set(Mode),
@@ -627,7 +627,7 @@ _global_command_templates: list[CommandTemplate] = [
     CommandTemplate(
         name="target",
         help=CommandHelp(
-            full_use_case_template="target [time|'office'|'remote'|'remote']",
+            full_use_case_template="target [time|'office'|'remote'|'current']",
             short_help_description="Displays or modifies the target time at work",
             full_help_description=(
                 " When run without arguments, this command prints the target time spent at work for the given date."

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -637,8 +637,8 @@ _global_command_templates: list[CommandTemplate] = [
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "target", "displays the target time at work for the given date."),
-                CommandUseCaseDescription({Mode.Today, Mode.Day}, "target <time>", "modifies the target time at work by the given amount."),
-                CommandUseCaseDescription({Mode.Today, Mode.Month}, "target <'office'|'remote'>", "displays the target time at work for the entire month of office or remote work."),
+                CommandUseCaseDescription(set(Mode), "target <time>", "modifies the target time at work by the given amount."),
+                CommandUseCaseDescription(set(Mode), "target <'office'|'remote'>", "displays the target time at work for the entire month of office or remote work."),
                 CommandUseCaseDescription({Mode.Today, Mode.Day}, "target <'current'>", "sets the target time at work to the time already spent at work on the given date."),
             ],
         ),

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -64,9 +64,15 @@ class CommandQuery:
     command: Command
     dates: list[Date]
     date_count: int
+    own_dates: list[Date]
+    own_date_count: int
+    multi_dates: list[Date]
+    multi_dates_count: int
     arguments: list[CommandArgument]
     argument_count: int
     raw_text: str
+    raw_full_input: str
+    order_index: int
 
 
 @dataclass(frozen=True)

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -99,24 +99,6 @@ class KeyManager: # TODO shorten codes
 
 _global_command_templates: list[CommandTemplate] = [
     CommandTemplate(
-        name="block",
-        help=CommandHelp(
-            full_use_case_template="block",
-            short_help_description="Prevents a date from being reset during recalculation",
-            full_help_description=(
-                " Marks the date as blocked, ensuring that its data is preserved when running 'calculate' or 'recalculate'."
-                " Both commands will skip resetting a blocked date, preserving its existing values while still updating the rest of the schedule."
-                " This allows you to protect specific dates from being overwritten while still updating the rest of the schedule automatically."
-            ).strip(),
-            use_case_description=[
-                CommandUseCaseDescription({Mode.Today, Mode.Day}, "block", ""),
-            ],
-        ),
-        supported_modes={Mode.Today, Mode.Day},
-        abbreviations=[],
-        valid_argument_types=[[]],
-    ),
-    CommandTemplate(
         name="calendar",
         help=CommandHelp(
             full_use_case_template="calendar",
@@ -128,23 +110,6 @@ _global_command_templates: list[CommandTemplate] = [
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "calendar", ""),
-            ],
-        ),
-        supported_modes=set(Mode),
-        abbreviations=[],
-        valid_argument_types=[[]],
-    ),
-    CommandTemplate(
-        name="calculate",
-        help=CommandHelp(
-            full_use_case_template="calculate",
-            short_help_description="Calculates the schedule based on the setup parameters",
-            full_help_description=(
-                " Calculates the work schedule for the given month according to the parameters set during the setup process."
-                " This is a 'hard reset' of the data, meaning that any previously entered data for specific dates will be overwritten."
-            ).strip(),
-            use_case_description=[
-                CommandUseCaseDescription(set(Mode), "calculate", ""),
             ],
         ),
         supported_modes=set(Mode),
@@ -485,26 +450,6 @@ _global_command_templates: list[CommandTemplate] = [
         valid_argument_types=[[]],
     ),
     CommandTemplate(
-        name="recalculate",
-        help=CommandHelp(
-            full_use_case_template="recalculate",
-            short_help_description="Recalculates the schedule while preserving data before and including the active date",
-            full_help_description=(
-                " Recalculates the work schedule for the given month based on the parameters set during the setup process."
-                " Unlike 'calculate', which performs a 'hard reset' of the entire schedule, 'recalculate' updates only the data"
-                " from the next date onward. Any data before and including the active date remains unchanged, ensuring past records"
-                " and the current day's data are preserved. "
-                " This allows for automatic updates while maintaining consistency with previously recorded work data."
-            ).strip(),
-            use_case_description=[
-                CommandUseCaseDescription(set(Mode), "recalculate", ""),
-            ],
-        ),
-        supported_modes=set(Mode),
-        abbreviations=[],
-        valid_argument_types=[[]],
-    ),
-    CommandTemplate(
         name="redo",
         help=CommandHelp(
             full_use_case_template="redo",
@@ -572,30 +517,6 @@ _global_command_templates: list[CommandTemplate] = [
         supported_modes=set(Mode),
         abbreviations=[],
         valid_argument_types=[[], [Number]],
-    ),
-    CommandTemplate(
-        name="setup",
-        help=CommandHelp(
-            full_use_case_template="setup [info]",
-            short_help_description="Starts the setup process or displays the current configuration",
-            full_help_description=(
-                " Starts the setup mode, where the user is prompted with a series of questions to configure their work schedule,"
-                " including preferred work days, hours, and other relevant parameters, within the context of the given month. If no"
-                " month is provided, the setup will be applied to the currently active date's month."
-                " The setup for the previous month is automatically used for the next month if no new setup was provided."
-                " Once setup is complete, the user must call the 'calculate' method to automatically generate the work schedule for the given month."
-                " The 'recalculate' method can be used to refresh the schedule while respecting any manually entered data for specific dates, unlike"
-                " 'calculate' which performs a 'hard reset' of the data."
-                "\nAdditionaly, 'setup info' displays the current configuration including all set parameters."
-            ).strip(),
-            use_case_description=[
-                CommandUseCaseDescription(set(Mode), "setup", "starts the setup process, prompting the user for configuration options."),
-                CommandUseCaseDescription(set(Mode), "setup <info>", "displays the current configuration with all set parameters."),
-            ],
-        ),
-        supported_modes=set(Mode),
-        abbreviations=[],
-        valid_argument_types=[[], [str]],
     ),
     CommandTemplate(
         name="start",

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -386,7 +386,7 @@ _global_command_templates: list[CommandTemplate] = [
             full_use_case_template="info",
             short_help_description="Displays detailed information for a specific date",
             full_help_description=(
-                " Displays all relevant information for a given date, including the time worked, target time, and various attributes such as "
+                " Displays all relevant information for a given date, including the time worked, target time, and various attributes such as"
                 " whether the day is marked as a holiday, workday, remote or office work, or a day off."
             ).strip(),
             use_case_description=[

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -604,12 +604,12 @@ _global_command_templates: list[CommandTemplate] = [
             full_use_case_template="rwr [value]",
             short_help_description="Displays or modifies the remote work ratio",
             full_help_description=(
-                "Displays the current remote work ratio (RWR) for the given date."
+                " Displays the current remote work ratio (RWR) for the given date."
                 " If called with an argument it sets the remote work ratio to that value for the specified date allowing users to adjust their remote work percentage."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "rwr", "displays the current remote work ratio for the given date."),
-                CommandUseCaseDescription(set(Mode), "rwr <value>", "sets the remote work ratio to the specified value for the given date."),
+                CommandUseCaseDescription(set(Mode), "rwr <value>", "sets the remote work ratio to the specified value for the given date's month."),
             ],
         ),
         supported_modes=set(Mode),

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -145,7 +145,7 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Displays the calendar for the month",
             full_help_description=(
                 " Displays the calendar for the month corresponding to the given date."
-                " Dates are marked using a color-coded legend which can be easily configured via 'config' command,"
+                f" Dates are marked using a color-coded legend which can be easily configured via {Color.Brightblue.value}config{Color.Reset.value} command,"
                 " this provides a clear distinction between different types of days."
             ).strip(),
             use_case_description=[
@@ -159,27 +159,30 @@ _global_command_templates: list[CommandTemplate] = [
     CommandTemplate(
         name="checkpoint",
         help=CommandHelp(
-            full_use_case_template="checkpoint [name]",
+            full_use_case_template="checkpoint [name] ['permanent']",
             short_help_description="Creates or lists available checkpoints",
             full_help_description=(
                 " Allows you to create a checkpoint which represents a saved state of the app."
-                " If no argument is provided, it lists all available checkpoints in current session."
-                " If a checkpoint name is provided, it creates or overwrites a checkpoint with that name."
-                " Checkpoints are session-specific and are deleted when the app is closed, meaning they only exist until you exit the app."
+                " If no argument is provided, it lists all available checkpoints."
+                " If a checkpoint name is provided, it creates a checkpoint with that name."
+                " Checkpoints by default are session-specific and are deleted when the app is closed, meaning they only exist until you exit the app."
+                f" If the optional {Color.Brightblue.value}permanent{Color.Reset.value} argument is included when creating a checkpoint,"
+                f" it becomes a permanent checkpoint that persists across sessions and is not deleted when the app is closed."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "checkpoint", "lists all available checkpoints"),
-                CommandUseCaseDescription(set(Mode), "checkpoint <name>", "creates or overwrites a checkpoint with the given name"),
+                CommandUseCaseDescription(set(Mode), "checkpoint <name>", "creates a checkpoint with the given name"),
+                CommandUseCaseDescription(set(Mode), "checkpoint <name> 'permanent'", "creates a permanent checkpoint with the given name"),
             ],
         ),
         supported_modes=set(Mode),
         abbreviations=[],
-        valid_argument_types=[[], [str]],
+        valid_argument_types=[[], [str], [str, str]],
     ),
     CommandTemplate(
         name="clear",
         help=CommandHelp(
-            full_use_case_template="clear [month]",
+            full_use_case_template="clear",
             short_help_description="Resets a date to its initial state",
             full_help_description=(
                 " Resets the given date to its initial state, as it was when first initialized."
@@ -237,8 +240,8 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 " Calculates the number of days required to reach the total work time while matching the daily work time as closely as possible to the provided amount."
                 " If no additional parameters are given, it calculates the required number of days based on the total work time specified."
-                " If 'remote' or 'office' is specified as the first argument, the calculation is limited to that specific type of work."
-                " If the 'clean' argument is included, the calculation ignores any previously logged work time and assumes a clean month."
+                f" If {Color.Brightblue.value}remote{Color.Reset.value} or {Color.Brightblue.value}office{Color.Reset.value} is specified as the first argument, the calculation is limited to that specific type of work."
+                f" If the {Color.Brightblue.value}clean{Color.Reset.value} argument is included, the calculation ignores any previously logged work time and assumes a clean month."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "days <minutes>", "calculates the number of days required to reach the monthly target work time while keeping daily work time as close as possible to the given amount"),
@@ -289,7 +292,7 @@ _global_command_templates: list[CommandTemplate] = [
             full_use_case_template="done",
             short_help_description="Sets the time spent at work to match the target time",
             full_help_description=(
-                " Sets the time spent at work to the value of the target time, which can be displayed using the 'target' command."
+                f" Sets the time spent at work to the value of the target time, which can be displayed using the {Color.Brightblue.value}target{Color.Reset.value} command."
                 " This command is useful for quickly aligning your time worked with the preset target, without needing to manually adjust the time."
             ).strip(),
             use_case_description=[
@@ -308,7 +311,7 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 " Marks the end of work to track time spent at work. If no time is provided, it uses the current system time."
                 " If a time is provided, it sets that as the end time."
-                " This command works together with the 'start' command to calculate the total time worked by subtracting the start time from the end time."
+                f" This command works together with the {Color.Brightblue.value}start{Color.Reset.value} command to calculate the total time worked by subtracting the start time from the end time."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription({Mode.Today, Mode.Day}, "end", "marks the end of work at the current system time."),
@@ -326,7 +329,7 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Exits the current mode or application",
             full_help_description=(
                 " Exits the app and saves the data if you are currently working in the today mode. "
-                " If you're working within the context of any other date, it will switch you back to the today mode."
+                " If you are working within the context of any other date, it will switch you back to the today mode."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "exit", ""),
@@ -361,7 +364,7 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Displays a list of all commands with short descriptions or detailed help for a specific command.",
             full_help_description=(
                 " Displays a list of all available commands along with short descriptions. "
-                " Alternatively, 'help <command-name>' can be used to get detailed information about a specific command."
+                f" Alternatively, {Color.Brightblue.value}help <command-name>{Color.Reset.value} can be used to get detailed information about a specific command."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "help", "displays a list of all commands with short descriptions."),
@@ -473,7 +476,8 @@ _global_command_templates: list[CommandTemplate] = [
                 f" These arguments can be referenced throughout the sequence by using the format {Color.Brightblue.value}<argument_name>{Color.Reset.value}."
                 f"\n\nTo avoid any problems during the macro definition, it is recommended to enclose the entire command sequence of the macro in quotes (single or double)."
                 f" This makes the text inside the quotes treated as a literal string, preventing any issues with special characters or spaces in the command sequence."
-                f" For example, defining a macro called {Color.Brightblue.value}custom-help{Color.Reset.value} that runs {Color.Brightblue.value}help{Color.Reset.value} on a user-specified command name (or 'macro' if no name is provided) would look like this:"
+                f" For example, defining a macro called {Color.Brightblue.value}custom-help{Color.Reset.value} that runs {Color.Brightblue.value}help{Color.Reset.value} on a user-specified command name "
+                f" (or {Color.Brightblue.value}macro{Color.Reset.value} if no name is provided) would look like this:"
                 f'\n  {Color.Blue.value}>> {Color.Brightblue.value}macro custom-help <command_name=macro> "help <command_name>"{Color.Reset.value}'
             ).strip(),
             use_case_description=[
@@ -494,8 +498,8 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 " Calculates the required daily work time to reach the total monthly work time, based on the target number of days provided."
                 " If no additional parameters are given, it calculates the required minutes per day based on the total monthly work time required."
-                " If 'remote' or 'office' is specified as the first argument, the calculation is restricted to that specific type of work."
-                " If the 'clean' argument is included, the calculation ignores any previously logged work time and assumes a clean month."
+                f" If {Color.Brightblue.value}remote{Color.Reset.value} or {Color.Brightblue.value}office{Color.Reset.value} is specified as the first argument, the calculation is restricted to that specific type of work."
+                f" If the {Color.Brightblue.value}clean{Color.Reset.value} argument is included, the calculation ignores any previously logged work time and assumes a clean month."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "minutes <days>", "calculates the daily minutes required to reach the monthly target work time within the given number of days"),
@@ -549,7 +553,7 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 " Re-applies the last command that was undone and altered the state of the data."
                 " If a count is provided, it re-applies that many commands at once."
-                " The history of commands that can be undone or redone is tracked and can be viewed using the {Color.Brightblue.value}history{Color.Reset.value} command."
+                f" The history of commands that can be undone or redone is tracked and can be viewed using the {Color.Brightblue.value}history{Color.Reset.value} command."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "redo", "re-applies the last undone command"),
@@ -583,8 +587,8 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Rolls back the app state to a specified checkpoint",
             full_help_description=(
                 " Rolls back the app state to a specified checkpoint. A checkpoint is a saved state created by the user using the"
-                " 'checkpoint' command. WorkTracker will revert to that state undoing or applying any changes made since"
-                " the checkpoint was created, regardless of any actions taken in the meantime."
+                f" {Color.Brightblue.value}checkpoint{Color.Reset.value} command."
+                f" WorkTracker will revert to that state undoing or applying any changes made since the checkpoint was created, regardless of any actions taken in the meantime."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "rollback <checkpoint>", ""),
@@ -592,7 +596,7 @@ _global_command_templates: list[CommandTemplate] = [
         ),
         supported_modes=set(Mode),
         abbreviations=[],
-        valid_argument_types=[[str]],
+        valid_argument_types=[[str], [int]],
     ),
     CommandTemplate(
         name="rwr",
@@ -620,7 +624,7 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 " Marks the start of work to track time spent at work. If no time is provided, it uses the current system time."
                 " If a time is provided, it sets that as the start time."
-                " This command works together with the 'end' command to precisely and with ease track the total time worked."
+                f" This command works together with the {Color.Brightblue.value}end{Color.Reset.value} command to precisely and with ease track the total time worked."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription({Mode.Today, Mode.Day}, "start", "marks the start of work at the current system time."),
@@ -655,8 +659,8 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 " When run without arguments, this command prints the target time spent at work for the given date."
                 " If a time is provided, it modifies the target time by the specified amount."
-                " The arguments 'office' and 'remote' display the target time for office and remote work for the entire month, respectively."
-                " The argument 'current' sets the target time to match the amount of time already worked on the current day."
+                f" The arguments {Color.Brightblue.value}office{Color.Reset.value} and {Color.Brightblue.value}remote{Color.Reset.value} display the target time for office and remote work for the entire month, respectively."
+                f" The argument {Color.Brightblue.value}current{Color.Reset.value} sets the target time to match the amount of time already worked on the current day."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "target", "displays the target time at work for the given date."),
@@ -676,7 +680,7 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Presents a brief guide on how to use WorkTracker",
             full_help_description=(
                 " Starts tutorial mode to walk you through a brief guide on how to use WorkTracker."
-                " Switch between pages by specifying a page number, to exit tutorial mode, type 'quit'."
+                f" Switch between pages by specifying a page number, to exit tutorial mode, type {Color.Brightblue.value}quit{Color.Reset.value}."
                 " If command is run with a page number provided, it will display the content of that specific page without entering the tutorial mode."
             ).strip(),
             use_case_description=[

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -6,7 +6,6 @@ from enum import Enum, auto
 from types import UnionType
 
 from work_tracker.common import AppData, Date, Mode
-# from work_tracker.error import ParserError
 from work_tracker.text.common import Color
 
 
@@ -98,6 +97,30 @@ class KeyManager: # TODO shorten codes
 
 
 _global_command_templates: list[CommandTemplate] = [
+    CommandTemplate(
+        name="alias",
+        help=CommandHelp(
+            full_use_case_template="(alias [name]) | (alias <name> <replacement_text...>)",
+            short_help_description="Displays, updates or creates aliases",
+            full_help_description=(
+                f" Aliases are simple text replacements that occur before command parsing."
+                f" When an alias is detected at the beginning of user input, it is expanded to its replacement text."
+                f" Unlike macros, aliases do not support arguments and are purely text-based substitutions."
+                f" Aliases can be layered, meaning one alias can reference another."
+                f"\n\nTo avoid any problems during the alias definition, it is recommended to enclose the entire command sequence of the macro in quotes (single or double)."
+                f" For example to define an alias that during runtime replaces the word {Color.Brightblue.value}ha{Color.Reset.value} with {Color.Brightblue.value}help alias{Color.Reset.value}, you would type the following:"
+                f'\n  {Color.Blue.value}>> {Color.Brightblue.value}alias ha "help alias"{Color.Reset.value}'
+            ).strip(),
+            use_case_description=[
+                CommandUseCaseDescription(set(Mode), "alias", "displays all available aliases"),
+                CommandUseCaseDescription(set(Mode), "alias <name>", "displays the definition of the specified alias"),
+                CommandUseCaseDescription(set(Mode), "alias <name> <replacement_text...>", "creates or overwrites an alias with the given name"),
+            ],
+        ),
+        supported_modes=set(Mode),
+        abbreviations=[],
+        valid_argument_types=[[], [str], [str, str, ...]],
+    ),
     CommandTemplate(
         name="calendar",
         help=CommandHelp(
@@ -210,6 +233,22 @@ _global_command_templates: list[CommandTemplate] = [
         supported_modes=set(Mode),
         abbreviations=[],
         valid_argument_types=[[TimeArgument], [str, TimeArgument], [TimeArgument, str], [str, TimeArgument, str]],
+    ),
+    CommandTemplate(
+        name="deletealias",
+        help=CommandHelp(
+            full_use_case_template="deletealias <name>",
+            short_help_description="Deletes the specified alias",
+            full_help_description=(
+                " Deletes the alias identified by the given name."
+            ).strip(),
+            use_case_description=[
+                CommandUseCaseDescription(set(Mode), "deletealias <name>", "deletes the alias with the specified name"),
+            ],
+        ),
+        supported_modes=set(Mode),
+        abbreviations=[],
+        valid_argument_types=[[str]],
     ),
     CommandTemplate(
         name="deletemacro",
@@ -395,9 +434,11 @@ _global_command_templates: list[CommandTemplate] = [
                 f" Macros act as reusable command sequences, allowing users to define custom methods that execute multiple commands (or other macros) in order."
                 f" A macro consists of an identifier (name) and optional or required arguments, which can be used within the command sequence."
                 f" Macros can also function as simple aliases for other commands."
-                f"\n\nMacro arguments must be specified using the format {Color.Brightblue.value}<argument_name>{Color.Reset.value}, and the first word after the macro identifier (excluding arguments in {Color.Brightblue.value}<>{Color.Reset.value}) marks the beginning of the macro's command sequence."
+                f"\n\nMacro arguments must be specified using the format {Color.Brightblue.value}<argument_name>{Color.Reset.value},"
+                f" and the first word after the macro identifier (excluding arguments in {Color.Brightblue.value}<>{Color.Reset.value}) marks the beginning of the macro's command sequence."
                 f" These arguments can be referenced throughout the sequence by using the format {Color.Brightblue.value}<argument_name>{Color.Reset.value}."
                 f"\n\nTo avoid any problems during the macro definition, it is recommended to enclose the entire command sequence of the macro in quotes (single or double)."
+                f" This makes the text inside the quotes treated as a literal string, preventing any issues with special characters or spaces in the command sequence."
                 f" For example, defining a macro called {Color.Brightblue.value}custom-help{Color.Reset.value} that runs {Color.Brightblue.value}help{Color.Reset.value} on a user-specified command name (or 'macro' if no name is provided) would look like this:"
                 f'\n  {Color.Blue.value}>> {Color.Brightblue.value}macro custom-help <command_name=macro> "help <command_name>"{Color.Reset.value}'
             ).strip(),

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -369,6 +369,8 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Marks a date as a holiday",
             full_help_description=(
                 " Marks a date as a holiday. As a result, this date is no longer treated as a workday, even if it was marked as one before."
+                " If the current monthly target work time matches fte-based calculation, it will be automatically updated to reflect the change in workdays."
+                " Otherwise the monthly target work time remains unchanged."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription({Mode.Today, Mode.Day}, "holiday", ""),
@@ -689,6 +691,8 @@ _global_command_templates: list[CommandTemplate] = [
             short_help_description="Marks a date as a work day",
             full_help_description=(
                 " Marks a date as a work day. As a result, this date is no longer treated as a holiday or weekend, even if it was marked as one before."
+                " If the current monthly target work time matches fte-based calculation, it will be automatically updated to reflect the change in workdays."
+                " Otherwise the monthly target work time remains unchanged."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription({Mode.Today, Mode.Day}, "workday", ""),

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -426,6 +426,22 @@ _global_command_templates: list[CommandTemplate] = [
         valid_argument_types=[[], [str]],
     ),
     CommandTemplate(
+        name="keyword",
+        help=CommandHelp(
+            full_use_case_template="keyword",
+            short_help_description="Displays a list of all available keywords with their descriptions and supported modes",
+            full_help_description=(
+                " Displays all available keywords, including their descriptions and the modes they support."
+            ).strip(),
+            use_case_description=[
+                CommandUseCaseDescription(set(Mode), "keyword", ""),
+            ],
+        ),
+        supported_modes=set(Mode),
+        abbreviations=[],
+        valid_argument_types=[[]],
+    ),
+    CommandTemplate(
         name="macro",
         help=CommandHelp(
             full_use_case_template="(macro [name]) | (macro {argument} <command_text...>)",

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -98,6 +98,22 @@ class KeyManager: # TODO shorten codes
 
 _global_command_templates: list[CommandTemplate] = [
     CommandTemplate(
+        name="absence",
+        help=CommandHelp(
+            full_use_case_template="absence",
+            short_help_description="Marks a date as an absence",
+            full_help_description=(
+                " Marks a date as an absence. When used within the context of a specific month it will mark all work days as absences within that month."
+            ).strip(),
+            use_case_description=[
+                CommandUseCaseDescription(set(Mode), "absence", ""),
+            ],
+        ),
+        supported_modes=set(Mode),
+        abbreviations=["absent"],
+        valid_argument_types=[[]],
+    ),
+    CommandTemplate(
         name="alias",
         help=CommandHelp(
             full_use_case_template="(alias [name]) | (alias <name> <replacement_text...>)",
@@ -200,9 +216,9 @@ _global_command_templates: list[CommandTemplate] = [
         name="dayoff",
         help=CommandHelp(
             full_use_case_template="dayoff",
-            short_help_description="Marks a date as a day off.",
+            short_help_description="Marks a date as a day off",
             full_help_description=(
-                " Marks a date as a day off. When used within the context of a specific month it will mark all dates containing work as days off within that month."
+                " Marks a date as a day off. When used within the context of a specific month it will mark all work days as days off within that month."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "dayoff", ""),
@@ -396,8 +412,9 @@ _global_command_templates: list[CommandTemplate] = [
             full_use_case_template="info",
             short_help_description="Displays detailed information for a specific date",
             full_help_description=(
-                " Displays all relevant information for a given date, including the time worked, target time, and various attributes such as"
-                " whether the day is marked as a holiday, workday, remote or office work, or a day off."
+                " Displays all relevant information for a given date."
+                " For a specific day, this includes the time worked, target time, and attributes such as whether the day is marked as a holiday or workday."
+                " For a month, this includes monthly target time, remote work ratio, and other month-level details."
             ).strip(),
             use_case_description=[
                 CommandUseCaseDescription(set(Mode), "info", ""),
@@ -496,27 +513,10 @@ _global_command_templates: list[CommandTemplate] = [
             full_use_case_template="office",
             short_help_description="Marks a date as office work",
             full_help_description=(
-                " Marks a date as office work. As a result, this date is no longer treated as a remote work, even if it was marked as one before."
+                " Marks a date as office work. When used within the context of a specific month it will mark all work days as office work within that month."
             ).strip(),
             use_case_description=[
-                CommandUseCaseDescription({Mode.Today, Mode.Day}, "office", ""),
-            ],
-        ),
-        supported_modes={Mode.Today, Mode.Day},
-        abbreviations=[],
-        valid_argument_types=[[]],
-    ),
-    CommandTemplate(
-        name="redo",
-        help=CommandHelp(
-            full_use_case_template="redo",
-            short_help_description="Re-applies the last undone command that altered the state of the data",
-            full_help_description=(
-                " Re-applies the last command that was undone and altered the state of the data."
-                " The history of commands that can be undone or redone is tracked and can be viewed using the 'history' command."
-            ).strip(),
-            use_case_description=[
-                CommandUseCaseDescription(set(Mode), "redo", ""),
+                CommandUseCaseDescription(set(Mode), "office", ""),
             ],
         ),
         supported_modes=set(Mode),
@@ -524,18 +524,54 @@ _global_command_templates: list[CommandTemplate] = [
         valid_argument_types=[[]],
     ),
     CommandTemplate(
+        name="present",
+        help=CommandHelp(
+            full_use_case_template="present",
+            short_help_description="Marks a date as being present at work",
+            full_help_description=(
+                " Marks a date as being present, clearing any absence or day off status."
+                " When used within the context of a specific month it will mark all work days as being present within that month."
+            ).strip(),
+            use_case_description=[
+                CommandUseCaseDescription(set(Mode), "present", ""),
+            ],
+        ),
+        supported_modes=set(Mode),
+        abbreviations=["working"],
+        valid_argument_types=[[]],
+    ),
+    CommandTemplate(
+        name="redo",
+        help=CommandHelp(
+            full_use_case_template="redo [count]",
+            short_help_description="Re-applies the last undone command that altered the state of the data",
+            full_help_description=(
+                " Re-applies the last command that was undone and altered the state of the data."
+                " If a count is provided, it re-applies that many commands at once."
+                " The history of commands that can be undone or redone is tracked and can be viewed using the {Color.Brightblue.value}history{Color.Reset.value} command."
+            ).strip(),
+            use_case_description=[
+                CommandUseCaseDescription(set(Mode), "redo", "re-applies the last undone command"),
+                CommandUseCaseDescription(set(Mode), "redo <count>", "re-applies the last <count> undone commands"),
+            ],
+        ),
+        supported_modes=set(Mode),
+        abbreviations=[],
+        valid_argument_types=[[], [int]],
+    ),
+    CommandTemplate(
         name="remote",
         help=CommandHelp(
             full_use_case_template="remote",
             short_help_description="Marks a date as remote work",
             full_help_description=(
-                " Marks a date as remote work. As a result, this date is no longer treated as a office work, even if it was marked as one before."
+                " Marks a date as remote work. When used within the context of a specific month it will mark all work days as remote work within that month."
             ).strip(),
             use_case_description=[
-                CommandUseCaseDescription({Mode.Today, Mode.Day}, "remote", ""),
+                CommandUseCaseDescription(set(Mode), "remote", ""),
             ],
         ),
-        supported_modes={Mode.Today, Mode.Day},
+        supported_modes=set(Mode),
         abbreviations=[],
         valid_argument_types=[[]],
     ),
@@ -654,19 +690,21 @@ _global_command_templates: list[CommandTemplate] = [
     CommandTemplate(
         name="undo",
         help=CommandHelp(
-            full_use_case_template="undo",
+            full_use_case_template="undo [count]",
             short_help_description="Undoes the last command executed that altered the state of the data",
             full_help_description=(
                 " Undoes the last command executed that altered the state of the data."
-                " The history of commands that can be undone or redone is tracked and can be viewed using the 'history' command."
+                " If a count is provided, it undoes that many commands at once."
+                f" The history of commands that can be undone or redone is tracked and can be viewed using the {Color.Brightblue.value}history{Color.Reset.value} command."
             ).strip(),
             use_case_description=[
-                CommandUseCaseDescription(set(Mode), "undo", ""),
+                CommandUseCaseDescription(set(Mode), "undo", "undoes the last command"),
+                CommandUseCaseDescription(set(Mode), "undo <count>", "undoes the last <count> commands"),
             ],
         ),
         supported_modes=set(Mode),
         abbreviations=[],
-        valid_argument_types=[[]],
+        valid_argument_types=[[], [int]],
     ),
     CommandTemplate(
         name="workday",

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -470,7 +470,7 @@ _global_command_templates: list[CommandTemplate] = [
             full_help_description=(
                 f" Macros act as reusable command sequences, allowing users to define custom methods that execute multiple commands (or other macros) in order."
                 f" A macro consists of an identifier (name) and optional or required arguments, which can be used within the command sequence."
-                f" Macros can also function as simple aliases for other commands."
+                f" The parser processes macros like any other command. Consequently, if you specify a date before a macro, that date is passed down to each individual command contained inside."
                 f"\n\nMacro arguments must be specified using the format {Color.Brightblue.value}<argument_name>{Color.Reset.value},"
                 f" and the first word after the macro identifier (excluding arguments in {Color.Brightblue.value}<>{Color.Reset.value}) marks the beginning of the macro's command sequence."
                 f" These arguments can be referenced throughout the sequence by using the format {Color.Brightblue.value}<argument_name>{Color.Reset.value}."

--- a/work_tracker/command/common.py
+++ b/work_tracker/command/common.py
@@ -4,6 +4,7 @@ import pickle
 from dataclasses import dataclass
 from enum import Enum, auto
 from types import UnionType
+from typing import Any
 
 from work_tracker.common import AppData, Date, Mode
 from work_tracker.text.common import Color
@@ -79,7 +80,7 @@ class ParseResult:
     queries: list[CommandQuery]
     # error: ParserError | None = None
     # TODO had to remove ParserError typehint due to circular imports, fix it in the future
-    error: any = None
+    error: Any = None
 
 
 class KeyManager: # TODO shorten codes

--- a/work_tracker/command/keyword_manager.py
+++ b/work_tracker/command/keyword_manager.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from dataclasses import dataclass
 
-from work_tracker.config import Config
 from work_tracker.common import Mode, ReadonlyAppState, classproperty
 
 
@@ -136,26 +135,3 @@ class KeywordManager:
                 return ""
         
         return ""
-
-    @classmethod
-    def expand_keywords(cls, text: str, state: ReadonlyAppState) -> str:
-        prefix: str = Config.data.input.keyword_prefix
-        
-        replacements = []
-        
-        # Get all keywords and their values
-        for keyword_info in cls.get_all_keywords(state):
-            keyword: str = keyword_with_prefix[len(prefix):]
-            value = cls.get_keyword_value(keyword_without_prefix, state)
-            
-            if value is not None and keyword_with_prefix in text:
-                replacements.append((keyword_with_prefix, value))
-        
-        # Sort by length (longest first) to avoid partial replacements
-        replacements.sort(key=lambda x: len(x[0]), reverse=True)
-        
-        # Perform replacements
-        for keyword, value in replacements:
-            text = text.replace(keyword, value)
-        
-        return text

--- a/work_tracker/command/keyword_manager.py
+++ b/work_tracker/command/keyword_manager.py
@@ -1,0 +1,161 @@
+from datetime import datetime, timedelta
+from dataclasses import dataclass
+
+from work_tracker.config import Config
+from work_tracker.common import Mode, ReadonlyAppState, classproperty
+
+
+@dataclass(frozen=True)
+class KeywordTemplate:
+    identifier: str
+    description: str
+    supported_modes: set[Mode]
+
+
+class KeywordManager:
+    _keywords: dict[str, KeywordTemplate] = {}
+    _initialized: bool = False
+
+    @classproperty
+    def keywords(cls) -> dict[str, KeywordTemplate]:
+        cls._check_initialization()
+        return cls._keywords # TODO deepcopy
+
+    @classproperty
+    def iterable_keywords(cls) -> list[KeywordTemplate]:
+        cls._check_initialization()
+        return list(cls._keywords.values())
+    
+    @classmethod
+    def _check_initialization(cls):
+        if not cls._initialized:
+            cls._keywords = cls._initialize_keywords()
+            cls._initialized = True
+
+    @classmethod
+    def _initialize_keywords(cls) -> dict[str, KeywordTemplate]:
+        return {
+            "today": KeywordTemplate(
+                identifier="today",
+                description="Current system date",
+                supported_modes={Mode.Today, Mode.Day, Mode.Month}
+            ),
+            "tomorrow": KeywordTemplate(
+                identifier="tomorrow",
+                description="Tomorrow's date",
+                supported_modes={Mode.Today, Mode.Day, Mode.Month}
+            ),
+            "yesterday": KeywordTemplate(
+                identifier="yesterday",
+                description="Yesterday's date",
+                supported_modes={Mode.Today, Mode.Day, Mode.Month}
+            ),
+            "nextday": KeywordTemplate(
+                identifier="nextday",
+                description="Next day from active date",
+                supported_modes={Mode.Today, Mode.Day}
+            ),
+            "prevday": KeywordTemplate(
+                identifier="prevday",
+                description="Previous day from active date",
+                supported_modes={Mode.Today, Mode.Day}
+            ),
+            "month": KeywordTemplate(
+                identifier="month",
+                description="Active month",
+                supported_modes={Mode.Today, Mode.Day, Mode.Month}
+            ),
+            "nextmonth": KeywordTemplate(
+                identifier="nextmonth",
+                description="Next month from active date",
+                supported_modes={Mode.Today, Mode.Day, Mode.Month}
+            ),
+            "prevmonth": KeywordTemplate(
+                identifier="prevmonth",
+                description="Previous month from active date",
+                supported_modes={Mode.Today, Mode.Day, Mode.Month}
+            ),
+        }
+
+    @classmethod
+    def _format_date(cls, date: datetime) -> str:
+        return date.strftime("%d.%m.%Y") # TODO it would be neat if this format was configurable, but the input must change too => parser would have to have dynamic logic
+
+    @classmethod
+    def _format_month(cls, date: datetime) -> str:
+        return date.strftime(".%m.%Y") # TODO check if this is possible to format easily via Date class
+
+    @classmethod
+    def get_keyword_value(cls, keyword: str, state: ReadonlyAppState) -> str:
+        match_state: tuple[str, Mode] = (keyword.lower(), state.mode)
+        match match_state:
+            case ('today', _): # TODO how is Mode.Today handled the same way ? comparing to the system time ?
+                today: datetime = datetime.now()
+                return cls._format_date(today)
+            
+            case ('tomorrow', _):
+                today: datetime = datetime.now()
+                return cls._format_date(today + timedelta(days=1))
+            
+            case ('yesterday', _):
+                today: datetime = datetime.now()
+                return cls._format_date(today - timedelta(days=1))
+            
+            case ('nextday', Mode.Month):
+                return ""
+            
+            case ('nextday', _):
+                active_datetime: datetime = state.active_date.fill_with_today().to_datetime()
+                return cls._format_date(active_datetime + timedelta(days=1))
+
+            case ('prevday', Mode.Month):
+                return ""
+            
+            case ('prevday', _):
+                active_datetime: datetime = state.active_date.fill_with_today().to_datetime()
+                return cls._format_date(active_datetime - timedelta(days=1))
+
+            case ('month', _):
+                return cls._format_month(datetime(state.active_date.year, state.active_date.month, 1))
+
+            case ('nextmonth', _):
+                if state.active_date.month == 12:
+                    next_month = datetime(state.active_date.year + 1, 1, 1)
+                else:
+                    next_month = datetime(state.active_date.year, state.active_date.month + 1, 1)
+                return cls._format_month(next_month)
+
+            case ('prevmonth', _):
+                if state.active_date.month == 1:
+                    prev_month = datetime(state.active_date.year - 1, 12, 1)
+                else:
+                    prev_month = datetime(state.active_date.year, state.active_date.month - 1, 1)
+                return cls._format_month(prev_month)
+
+            case _:
+                return ""
+        
+        return ""
+
+    @classmethod
+    def expand_keywords(cls, text: str, state: ReadonlyAppState) -> str:
+        prefix: str = Config.data.input.keyword_prefix
+        
+        replacements = []
+        
+        # Get all keywords and their values
+        for keyword_info in cls.get_all_keywords(state):
+            keyword: str = keyword_with_prefix[len(prefix):]
+            value = cls.get_keyword_value(keyword_without_prefix, state)
+            
+            if value is not None and keyword_with_prefix in text:
+                replacements.append((keyword_with_prefix, value))
+        
+        # Sort by length (longest first) to avoid partial replacements
+        replacements.sort(key=lambda x: len(x[0]), reverse=True)
+        
+        # Perform replacements
+        for keyword, value in replacements:
+            text = text.replace(keyword, value)
+        
+        return text

--- a/work_tracker/command/macro_manager.py
+++ b/work_tracker/command/macro_manager.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from work_tracker.common import get_data_path
+from work_tracker.common import get_data_path, classproperty
 
 
 @dataclass(frozen=True)
@@ -21,14 +21,12 @@ class MacroManager:
     _macros: dict[str, MacroTemplate] = {}
     _initialized: bool = False
 
-    @classmethod
-    @property
+    @classproperty
     def macros(cls) -> dict[str, MacroTemplate]:
         cls._check_initialization()
         return cls._macros # TODO deepcopy
 
-    @classmethod
-    @property
+    @classproperty
     def iterable_macros(cls) -> list[MacroTemplate]:
         cls._check_initialization()
         return list(cls._macros.values())

--- a/work_tracker/command/macro_manager.py
+++ b/work_tracker/command/macro_manager.py
@@ -76,12 +76,12 @@ class MacroManager:
                 if not all(re.match(r"^<[^<>]+>$", argument) for argument in arguments):
                     raise Exception() # TODO
 
-                default_values: list[any] = []
+                default_values: list[str|None] = []
                 parsed_arguments: list[str] = []
                 for argument in arguments:
                     if "=" in argument:
                         name, value = argument[1:-1].split("=", 1)
-                        default_values.append(value)
+                        default_values.append('') if value.lower() == "null" else default_values.append(value)
                         parsed_arguments.append(f"{name}")
                     else:
                         default_values.append(None)

--- a/work_tracker/command/macro_manager.py
+++ b/work_tracker/command/macro_manager.py
@@ -11,7 +11,7 @@ class MacroTemplate:
     raw: str
     command_text: str
     arguments: list[str]
-    default_argument_values: list[str]
+    default_argument_values: list[str|None]
 
 
 __macro_version__: int = 1

--- a/work_tracker/common.py
+++ b/work_tracker/common.py
@@ -6,7 +6,7 @@ import os
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Type, Callable
+from typing import Type, Callable, Any
 
 import appdirs
 from multimethod import multimethod
@@ -35,24 +35,24 @@ def get_data_path() -> Path:
     return Path(data_path).absolute()
 
 
-def find_first_not_fulfilling(items: list[any], predicate: Callable[[list[any]], bool]) -> any | None:
+def find_first_not_fulfilling(items: list[Any], predicate: Callable[[list[Any]], bool]) -> any | None:
     return next((item for item in items if not predicate(item)), None)
 
 
 class KeyDefaultDict(defaultdict):
-    def __init__(self, function: Callable[[any], any]):
+    def __init__(self, function: Callable[[Any], Any]):
         super().__init__(None)
-        self.function: Callable[[any], any] = function
+        self.function: Callable[[Any], Any] = function
 
-    def __missing__(self, key) -> any:
-        value: any = self.function(key)
+    def __missing__(self, key) -> Any:
+        value: Any = self.function(key)
         self[key] = value
         return value
 
     def __reduce__(self):
         return self.__class__, (self.function,), dict(self)
 
-    def __setstate__(self, state: any):
+    def __setstate__(self, state: Any):
         self.update(state)
 
 

--- a/work_tracker/common.py
+++ b/work_tracker/common.py
@@ -483,6 +483,8 @@ class AppData:
                 delattr(month_data, 'target_office_days')
             if hasattr(month_data, 'target_remote_days'):
                 delattr(month_data, 'target_remote_days')
+        
+        self._version = 2
 
     def update_data_to_latest_version(self):
         # if loading a very old version run each updater in order A -> A+1 -> A+2 -> A+3 -> ... B

--- a/work_tracker/common.py
+++ b/work_tracker/common.py
@@ -314,30 +314,42 @@ class Date:
         return normalized_dates
 
 
+class AttendanceType(Enum):
+    PRESENT = auto()
+    DAYOFF = auto()
+    ABSENCE = auto()
+
+
+class DayType(Enum):
+    WORKDAY = auto()
+    WEEKEND = auto()
+    HOLIDAY = auto()
+
+
+class WorkLocation(Enum):
+    UNSPECIFIED = auto()
+    REMOTE = auto()
+    OFFICE = auto()
+
+
 @dataclass
 class DayData: # add setters for remote/office so they autofill properly
-    is_a_work_day: bool = False
+    attendance_type: AttendanceType = AttendanceType.PRESENT
+    day_type: DayType = DayType.WORKDAY
+    work_location: WorkLocation = WorkLocation.UNSPECIFIED  
     minutes_at_work: int = 0
     target_minutes: int = 0
-    remote_work: bool | None = None
-    office_work: bool | None = None
-    is_a_day_off: bool = False
     work_start: Time | None = None
     work_end: Time | None = None
 
-    def __post_init__(self):
-        if self.is_a_work_day and self.remote_work is None:
-            self.remote_work = False
-        if self.is_a_work_day and self.office_work is None:
-            self.office_work = False
-
-    def reset(self, is_a_work_day: bool = False):
-        self.is_a_work_day = is_a_work_day
+    def reset(self, day_type: DayType = DayType.WORKDAY):
+        self.attendance_type = AttendanceType.PRESENT
+        self.day_type = day_type
+        self.work_location = WorkLocation.UNSPECIFIED
         self.minutes_at_work = 0
         self.target_minutes = 0
-        self.remote_work = False if is_a_work_day else None
-        self.office_work = False if is_a_work_day else None
-        self.is_a_day_off = False
+        self.work_start = None
+        self.work_end = None
 
 
 @dataclass
@@ -345,37 +357,17 @@ class MonthData:
     target_minutes: int
     remote_work_ratio: float
     fte: float = 1.0
-    target_office_days: int | None = None
-    target_remote_days: int | None = None
+    # v2 deleted
+    # target_office_days: int | None = None
+    # target_remote_days: int | None = None
 
 
-class WorkStrategy(Enum):
-    Default = auto()
-    Quick = auto()
-
-
-@dataclass
-class WorkSetup:
-    default_fte: float = 1.0
-    preferred_weekdays: list[int] = field(default_factory=list)
-    non_availability_weekdays: list[int] = field(default_factory=list)
-    default_remote_work_ratio: float = 0.4
-    preferred_remote_weekdays: list[int] = field(default_factory=list)
-    preferred_office_day_length_in_minutes: int | None = 480
-    preferred_remote_day_length_in_minutes: int | None = 480
-    office_day_max_length_in_minutes: int | None = 600
-    remote_day_max_length_in_minutes: int | None = 600
-    each_weekday_max_length_in_minutes: list[int | None] = field(default_factory=lambda: [None, None, None, None, None])
-    strategy: WorkStrategy = WorkStrategy.Default
-
-
-__data_version__: int = 1
+__data_version__: int = 2
 
 
 @dataclass
 class AppData:
     country_code: str
-    setup: WorkSetup = field(init=False)
     day: defaultdict[Date, DayData] = field(init=False) # when using KeyDefaultDict as a typehint pycharm IDE breaks and stops suggesting any methods or properties
     month: defaultdict[Date, MonthData] = field(init=False)
     calendar: CoreCalendar = field(init=False, repr=False)
@@ -383,7 +375,6 @@ class AppData:
 
     def __post_init__(self): # this runs only once when user creates new AppData (first time prompt)
         self._version = __data_version__
-        self.setup = WorkSetup()
 
         self.calendar = AppData._determine_country(self.country_code)
         if self.calendar is None:
@@ -401,17 +392,32 @@ class AppData:
         return None
 
     def _on_day_initialization(self, date: Date) -> DayData:
-        return DayData(is_a_work_day=self.calendar.is_working_day(date.to_datetime()))
+        datetime_date: datetime.date = date.to_datetime()
+        
+        if self.calendar.is_working_day(datetime_date):
+            day_type = DayType.WORKDAY
+        elif self.calendar.is_holiday(datetime_date):
+            day_type = DayType.HOLIDAY
+        else:
+            day_type = DayType.WEEKEND
+        
+        return DayData(
+            day_type=day_type,
+            attendance_type=AttendanceType.PRESENT,
+            work_location=WorkLocation.UNSPECIFIED
+        )
         
     def _on_month_initialization(self, date: Date) -> MonthData:
-        target_minutes_total: int = sum([480 * self.setup.default_fte if self.calendar.is_working_day(day.to_datetime()) else 0 for day in date.days_in_a_month()])
-        return MonthData(target_minutes=target_minutes_total, remote_work_ratio=self.setup.default_remote_work_ratio, fte=self.setup.default_fte)
+        from work_tracker.config import Config
+        default_fte: float = Config.data.command.fte.default_value
+        default_remote_work_ratio: float = Config.data.command.rwr.default_value
+        target_minutes_total: int = sum([480 * default_fte if self.calendar.is_working_day(day.to_datetime()) else 0 for day in date.days_in_a_month()])
+        return MonthData(target_minutes=target_minutes_total, remote_work_ratio=default_remote_work_ratio, fte=default_fte)
 
     def copy_from(self, data: AppData):
         if self._version != data._version:
             raise Exception() # TODO
         self.country_code = data.country_code
-        self.setup = data.setup
         self.day = data.day
         self.month = data.month
         self.calendar = data.calendar
@@ -423,9 +429,68 @@ class AppData:
     def is_latest_data_version(self) -> bool:
         return self.version == __data_version__
 
+    def _update_data_to_v2(self):
+        for date, day_data in self.day.items():
+            # get old values
+            old_is_a_work_day: bool = getattr(day_data, 'is_a_work_day', False)
+            old_is_a_day_off: bool = getattr(day_data, 'is_a_day_off', False)
+            old_remote_work: bool | None = getattr(day_data, 'remote_work', None)
+            old_office_work: bool | None = getattr(day_data, 'office_work', None)
+            # config attendance_type
+            attendance_type: AttendanceType
+            if old_is_a_day_off:
+                attendance_type = AttendanceType.DAYOFF
+            else:
+                attendance_type = AttendanceType.PRESENT
+            # config day_type
+            day_type: DayType
+            if old_is_a_work_day:
+                day_type = DayType.WORKDAY
+            else:
+                datetime_date: datetime.date = date.to_datetime()
+                if self.calendar.is_holiday(datetime_date):
+                    day_type = DayType.HOLIDAY
+                else:
+                    day_type = DayType.WEEKEND
+            # config work_location
+            work_location: WorkLocation
+            if old_remote_work is True:
+                work_location = WorkLocation.REMOTE
+            elif old_office_work is True:
+                work_location = WorkLocation.OFFICE
+            else:
+                work_location = WorkLocation.UNSPECIFIED
+            # setup new fields
+            day_data.attendance_type = attendance_type
+            day_data.day_type = day_type
+            day_data.work_location = work_location
+            # remove old fields
+            if hasattr(day_data, 'is_a_work_day'):
+                delattr(day_data, 'is_a_work_day')
+            if hasattr(day_data, 'is_a_day_off'):
+                delattr(day_data, 'is_a_day_off')
+            if hasattr(day_data, 'remote_work'):
+                delattr(day_data, 'remote_work')
+            if hasattr(day_data, 'office_work'):
+                delattr(day_data, 'office_work')
+        
+        # remove old appData field
+        if hasattr(self, 'setup'):
+            delattr(self, 'setup')
+        # remove old monthData fields
+        for date, month_data in self.month.items():
+            if hasattr(month_data, 'target_office_days'):
+                delattr(month_data, 'target_office_days')
+            if hasattr(month_data, 'target_remote_days'):
+                delattr(month_data, 'target_remote_days')
+
     def update_data_to_latest_version(self):
         # if loading a very old version run each updater in order A -> A+1 -> A+2 -> A+3 -> ... B
-        pass
+        current_version: int = self._version
+        
+        if current_version == 1:
+            self._update_data_to_v2()
+            current_version = 2
 
 
 class Mode(Enum):

--- a/work_tracker/config.py
+++ b/work_tracker/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import yaml
 from pydantic import BaseModel
 
-from work_tracker.common import get_data_path
+from work_tracker.common import get_data_path, classproperty
 
 
 class CalendarCommandConfig(BaseModel):
@@ -88,8 +88,7 @@ class Config:
     def ready(cls) -> bool:
         return cls.data is not None
 
-    @classmethod
-    @property
+    @classproperty
     def data(cls) -> MainConfig:
         if cls._data is None:
             cls._data = MainConfig.load()

--- a/work_tracker/config.py
+++ b/work_tracker/config.py
@@ -19,6 +19,17 @@ class CalendarCommandConfig(BaseModel):
     remote_background_color: str | None
     dayoff_foreground_color: str | None
     dayoff_background_color: str | None
+    # v2
+    remote_incomplete_background_color: str | None
+    remote_incomplete_foreground_color: str | None
+    office_incomplete_background_color: str | None
+    office_incomplete_foreground_color: str | None
+    absence_foreground_color: str | None
+    absence_background_color: str | None
+
+
+class FteCommandConfig(BaseModel): # v2
+    default_value: float
 
 
 class HelpCommandConfig(BaseModel):
@@ -28,10 +39,16 @@ class HelpCommandConfig(BaseModel):
     command_use_case_bullet_point_symbol: str
 
 
+class RwrCommandConfig(BaseModel): # v2
+    default_value: float
+
 class CommandConfig(BaseModel):
     undo_history_size: int
     calendar: CalendarCommandConfig
     help: HelpCommandConfig
+    # v2
+    fte: FteCommandConfig
+    rwr: RwrCommandConfig
 
 
 class InputConfig(BaseModel):
@@ -57,6 +74,8 @@ class FrameConfig(BaseModel):
 class OutputConfig(BaseModel):
     max_width: int
     frame: FrameConfig
+    # v2
+    error_color: str
 
 
 __config_version__: int = 2
@@ -80,9 +99,23 @@ class MainConfig(BaseModel):
         raw_data["input"]["time_add_prefix"] = raw_data.pop("time_add_prefix", "+")
         raw_data["input"]["time_subtract_prefix"] = raw_data.pop("time_subtract_prefix", "-")
         raw_data["input"]["keyword_prefix"] = raw_data.pop("keyword_prefix", "$")
-        
+
+        raw_data["command"]["calendar"]["absence_background_color"] = raw_data["command"]["calendar"].get("absence_background_color", None)
+        raw_data["command"]["calendar"]["absence_foreground_color"] = raw_data["command"]["calendar"].get("absence_foreground_color", "brightblue")
+        raw_data["command"]["calendar"]["office_incomplete_background_color"] = raw_data["command"]["calendar"].get("office_incomplete_background_color", None)
+        raw_data["command"]["calendar"]["office_incomplete_foreground_color"] = raw_data["command"]["calendar"].get("office_incomplete_foreground_color", "red")
+        raw_data["command"]["calendar"]["remote_incomplete_background_color"] = raw_data["command"]["calendar"].get("remote_incomplete_background_color", None)
+        raw_data["command"]["calendar"]["remote_incomplete_foreground_color"] = raw_data["command"]["calendar"].get("remote_incomplete_foreground_color", "green")
+
+        raw_data["command"].setdefault("fte", {})
+        raw_data["command"]["fte"]["default_value"] = raw_data["command"]["fte"].get("default_value", 1.0)
+        raw_data["command"].setdefault("rwr", {})
+        raw_data["command"]["rwr"]["default_value"] = raw_data["command"]["rwr"].get("default_value", 0.4)
+
+        raw_data["output"]["error_color"] = raw_data["output"].get("error_color", "brightred")
+
         raw_data["version"] = 2
-        
+
     @classmethod
     def _update_config_data_to_latest_version(cls, raw_data: dict[str, any]):
         # just like data, update to target version step by step: A -> A+1 -> A+2 -> ... -> B

--- a/work_tracker/config.py
+++ b/work_tracker/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from path import Path
 import yaml
 from pydantic import BaseModel
 
@@ -37,6 +38,13 @@ class InputConfig(BaseModel):
     command_chain_symbol: str
     prefix: str
     sub_prefix: str
+    # v2
+    input_history_size: int
+    multi_date_start_symbol: str
+    multi_date_end_symbol: str
+    time_add_prefix: str
+    time_subtract_prefix: str
+    keyword_prefix: str
 
 
 class FrameConfig(BaseModel):
@@ -51,7 +59,7 @@ class OutputConfig(BaseModel):
     frame: FrameConfig
 
 
-__config_version__: int = 1
+__config_version__: int = 2
 
 
 class MainConfig(BaseModel):
@@ -60,25 +68,29 @@ class MainConfig(BaseModel):
     input: InputConfig
     output: OutputConfig
 
-    @classmethod
-    def load(cls) -> MainConfig:
-        with open(get_data_path().joinpath("config.yaml"), "r") as file:
-            raw_data: dict[str, any] = yaml.safe_load("".join(file))
-
-        if not cls._is_latest_config_version(raw_data):
-            cls._update_config_data_to_latest_version(raw_data)
-
-        return MainConfig(**raw_data)
-
     @staticmethod
     def _is_latest_config_version(raw_data: dict[str, any]) -> bool:
         return raw_data.get("version") == __config_version__
 
     @staticmethod
-    def _update_config_data_to_latest_version(raw_data: dict[str, any]) -> dict[str, any]:
+    def _update_config_data_to_v2(raw_data: dict[str, any]):
+        raw_data["input"]["input_history_size"] = raw_data["input"].get("input_history_size", 1000)
+        raw_data["input"]["multi_date_start_symbol"] = raw_data.pop("multi_date_start_symbol", "(")
+        raw_data["input"]["multi_date_end_symbol"] = raw_data.pop("multi_date_end_symbol", ")")
+        raw_data["input"]["time_add_prefix"] = raw_data.pop("time_add_prefix", "+")
+        raw_data["input"]["time_subtract_prefix"] = raw_data.pop("time_subtract_prefix", "-")
+        raw_data["input"]["keyword_prefix"] = raw_data.pop("keyword_prefix", "$")
+        
+        raw_data["version"] = 2
+        
+    @classmethod
+    def _update_config_data_to_latest_version(cls, raw_data: dict[str, any]):
         # just like data, update to target version step by step: A -> A+1 -> A+2 -> ... -> B
-        # remember to save the file, after update !
-        pass
+        current_version: int = raw_data.get("version", 1)
+
+        if current_version == 1:
+            cls._update_config_data_to_v2(raw_data)
+            current_version = 2
 
 
 class Config:
@@ -91,10 +103,32 @@ class Config:
     @classproperty
     def data(cls) -> MainConfig:
         if cls._data is None:
-            cls._data = MainConfig.load()
+            cls._load()
         return cls._data
+
+    @classproperty
+    def config_path(cls) -> Path:
+        return get_data_path().joinpath("config.yaml")
+
+    @classmethod
+    def _load(cls):
+        with open(cls.config_path, "r") as file:
+            raw_data: dict[str, any] = yaml.safe_load("".join(file))
+
+        was_updated: bool = False
+        if not MainConfig._is_latest_config_version(raw_data):
+            with open(get_data_path().joinpath("config.yaml.backup"), "w") as file:
+                file.write(yaml.safe_dump(raw_data, indent=4))
+            
+            MainConfig._update_config_data_to_latest_version(raw_data)
+            was_updated = True
+
+        cls._data = MainConfig(**raw_data)
+        if was_updated:
+            cls.save()
 
     @classmethod
     def save(cls):
-        with open(get_data_path().joinpath("config.yaml"), "w") as file:
-            file.write(yaml.safe_dump(cls.data.dict(), indent=4))
+        with open(cls.config_path, "w") as file:
+            file.write(yaml.safe_dump(cls.data.model_dump(), indent=4))
+

--- a/work_tracker/config.py
+++ b/work_tracker/config.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from path import Path
 import yaml
+from path import Path
 from pydantic import BaseModel
 
 from work_tracker.common import get_data_path, classproperty
@@ -44,6 +44,7 @@ class HelpCommandConfig(BaseModel):
 class RwrCommandConfig(BaseModel): # v2
     default_value: float
 
+
 class CommandConfig(BaseModel):
     undo_history_size: int
     calendar: CalendarCommandConfig
@@ -53,17 +54,26 @@ class CommandConfig(BaseModel):
     rwr: RwrCommandConfig
 
 
+class InputDateConfig(BaseModel):
+    multi_start_symbol: str
+    multi_end_symbol: str
+    normalize: bool
+
+
+class InputTimeConfig(BaseModel):
+    add_prefix: str
+    subtract_prefix: str
+
+
 class InputConfig(BaseModel):
     command_chain_symbol: str
     prefix: str
     sub_prefix: str
     # v2
-    input_history_size: int
-    multi_date_start_symbol: str
-    multi_date_end_symbol: str
-    time_add_prefix: str
-    time_subtract_prefix: str
     keyword_prefix: str
+    history_size: int
+    date: InputDateConfig
+    time: InputTimeConfig
 
 
 class FrameConfig(BaseModel):
@@ -95,12 +105,15 @@ class MainConfig(BaseModel):
 
     @staticmethod
     def _update_config_data_to_v2(raw_data: dict[str, Any]):
-        raw_data["input"]["input_history_size"] = raw_data["input"].get("input_history_size", 1000)
-        raw_data["input"]["multi_date_start_symbol"] = raw_data.pop("multi_date_start_symbol", "(")
-        raw_data["input"]["multi_date_end_symbol"] = raw_data.pop("multi_date_end_symbol", ")")
-        raw_data["input"]["time_add_prefix"] = raw_data.pop("time_add_prefix", "+")
-        raw_data["input"]["time_subtract_prefix"] = raw_data.pop("time_subtract_prefix", "-")
+        raw_data["input"]["history_size"] = raw_data["input"].get("history_size", 1000)
         raw_data["input"]["keyword_prefix"] = raw_data.pop("keyword_prefix", "$")
+        raw_data["input"].setdefault("date", {})
+        raw_data["input"]["date"]["multi_start_symbol"] = raw_data.pop("multi_start_symbol", "(")
+        raw_data["input"]["date"]["multi_end_symbol"] = raw_data.pop("multi_end_symbol", ")")
+        raw_data["input"]["date"]["normalize"] = raw_data.pop("normalize", False)
+        raw_data["input"].setdefault("time", {})
+        raw_data["input"]["add_prefix"] = raw_data.pop("add_prefix", "+")
+        raw_data["input"]["subtract_prefix"] = raw_data.pop("subtract_prefix", "-")
 
         raw_data["command"]["calendar"]["absence_background_color"] = raw_data["command"]["calendar"].get("absence_background_color", None)
         raw_data["command"]["calendar"]["absence_foreground_color"] = raw_data["command"]["calendar"].get("absence_foreground_color", "brightblue")

--- a/work_tracker/config.py
+++ b/work_tracker/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from path import Path
 import yaml
 from pydantic import BaseModel
@@ -88,11 +90,11 @@ class MainConfig(BaseModel):
     output: OutputConfig
 
     @staticmethod
-    def _is_latest_config_version(raw_data: dict[str, any]) -> bool:
+    def _is_latest_config_version(raw_data: dict[str, Any]) -> bool:
         return raw_data.get("version") == __config_version__
 
     @staticmethod
-    def _update_config_data_to_v2(raw_data: dict[str, any]):
+    def _update_config_data_to_v2(raw_data: dict[str, Any]):
         raw_data["input"]["input_history_size"] = raw_data["input"].get("input_history_size", 1000)
         raw_data["input"]["multi_date_start_symbol"] = raw_data.pop("multi_date_start_symbol", "(")
         raw_data["input"]["multi_date_end_symbol"] = raw_data.pop("multi_date_end_symbol", ")")
@@ -117,7 +119,7 @@ class MainConfig(BaseModel):
         raw_data["version"] = 2
 
     @classmethod
-    def _update_config_data_to_latest_version(cls, raw_data: dict[str, any]):
+    def _update_config_data_to_latest_version(cls, raw_data: dict[str, Any]):
         # just like data, update to target version step by step: A -> A+1 -> A+2 -> ... -> B
         current_version: int = raw_data.get("version", 1)
 
@@ -146,7 +148,7 @@ class Config:
     @classmethod
     def _load(cls):
         with open(cls.config_path, "r") as file:
-            raw_data: dict[str, any] = yaml.safe_load("".join(file))
+            raw_data: dict[str, Any] = yaml.safe_load("".join(file))
 
         was_updated: bool = False
         if not MainConfig._is_latest_config_version(raw_data):

--- a/work_tracker/config.py
+++ b/work_tracker/config.py
@@ -112,8 +112,8 @@ class MainConfig(BaseModel):
         raw_data["input"]["date"]["multi_end_symbol"] = raw_data.pop("multi_end_symbol", ")")
         raw_data["input"]["date"]["normalize"] = raw_data.pop("normalize", False)
         raw_data["input"].setdefault("time", {})
-        raw_data["input"]["add_prefix"] = raw_data.pop("add_prefix", "+")
-        raw_data["input"]["subtract_prefix"] = raw_data.pop("subtract_prefix", "-")
+        raw_data["input"]["time"]["add_prefix"] = raw_data.pop("add_prefix", "+")
+        raw_data["input"]["time"]["subtract_prefix"] = raw_data.pop("subtract_prefix", "-")
 
         raw_data["command"]["calendar"]["absence_background_color"] = raw_data["command"]["calendar"].get("absence_background_color", None)
         raw_data["command"]["calendar"]["absence_foreground_color"] = raw_data["command"]["calendar"].get("absence_foreground_color", "brightblue")

--- a/work_tracker/data/default.aliases.txt
+++ b/work_tracker/data/default.aliases.txt
@@ -6,3 +6,4 @@ q | exit && exit
 ms | $month status
 mo | minutes office
 mr | minutes remote
+s | save

--- a/work_tracker/data/default.aliases.txt
+++ b/work_tracker/data/default.aliases.txt
@@ -1,0 +1,8 @@
+1
+h | help
+e | exit
+c | calendar
+q | exit && exit
+ms | $month status
+mo | minutes office
+mr | minutes remote

--- a/work_tracker/data/default.config.yaml
+++ b/work_tracker/data/default.config.yaml
@@ -28,15 +28,18 @@ command:
         default_value: 0.4
     undo_history_size: 50
 input:
-    command_chain_symbol: '&&'
     prefix: '>>'
     sub_prefix: ':'
-    input_history_size: 1000
-    multi_date_end_symbol: )
-    multi_date_start_symbol: (
-    time_add_prefix: +
-    time_subtract_prefix: '-'
+    command_chain_symbol: '&&'
     keyword_prefix: $
+    history_size: 1000
+    date:
+        multi_start_symbol: (
+        multi_end_symbol: )
+        normalize: false
+    time:
+        add_prefix: +
+        subtract_prefix: '-'
 output:
     frame:
         padding: 1

--- a/work_tracker/data/default.config.yaml
+++ b/work_tracker/data/default.config.yaml
@@ -21,6 +21,12 @@ input:
     command_chain_symbol: '&&'
     prefix: '>>'
     sub_prefix: ':'
+    input_history_size: 1000
+    multi_date_end_symbol: )
+    multi_date_start_symbol: (
+    time_add_prefix: +
+    time_subtract_prefix: '-'
+    keyword_prefix: $
 output:
     frame:
         padding: 1
@@ -28,4 +34,4 @@ output:
         title_left_side_padding: 2
         title_padding: 1
     max_width: 80
-version: 1
+version: 2

--- a/work_tracker/data/default.config.yaml
+++ b/work_tracker/data/default.config.yaml
@@ -1,21 +1,31 @@
 command:
     calendar:
-        dayoff_background_color: null
-        dayoff_foreground_color: brightmagenta
-        holiday_background_color: null
-        holiday_foreground_color: brightgreen
-        office_background_color: null
-        office_foreground_color: brightred
-        remote_background_color: null
-        remote_foreground_color: brightblue
         title_color: null
         weekend_background_color: null
         weekend_foreground_color: yellow
+        holiday_background_color: null
+        holiday_foreground_color: brightmagenta
+        dayoff_background_color: null
+        dayoff_foreground_color: brightcyan
+        remote_background_color: null
+        remote_foreground_color: brightgreen
+        office_background_color: null
+        office_foreground_color: brightred
+        remote_incomplete_background_color: null
+        remote_incomplete_foreground_color: green
+        office_incomplete_background_color: null
+        office_incomplete_foreground_color: red
+        absence_background_color: null
+        absence_foreground_color: brightblue
+    fte:
+        default_value: 1.0
     help:
         command_list_description_padding: 2
         command_use_case_bullet_point_symbol: '- '
         command_use_case_description_padding: 4
         command_use_case_indent_size: 2
+    rwr:
+        default_value: 0.4
     undo_history_size: 50
 input:
     command_chain_symbol: '&&'
@@ -34,4 +44,5 @@ output:
         title_left_side_padding: 2
         title_padding: 1
     max_width: 80
+    error_color: brightred
 version: 2

--- a/work_tracker/data/default.macros.txt
+++ b/work_tracker/data/default.macros.txt
@@ -2,4 +2,5 @@
 o8 | office && 8:00
 r8 | remote && 8:00
 o <amount> | office && target <amount> 
-r <amount> | remote && target <amount> 
+r <amount> | remote && target <amount>
+save <name=$today> | checkpoint <name> permanent

--- a/work_tracker/data/default.macros.txt
+++ b/work_tracker/data/default.macros.txt
@@ -1,6 +1,5 @@
 1
-h <command=null> | help <command>
-e | exit
-c <month=null> | <month> calendar
 o8 | office && 8:00
 r8 | remote && 8:00
+o <amount> | office && target <amount> 
+r <amount> | remote && target <amount> 

--- a/work_tracker/data/default.macros.txt
+++ b/work_tracker/data/default.macros.txt
@@ -1,6 +1,6 @@
 1
-h | help
+h <command=null> | help <command>
 e | exit
-c <month> | <month> calendar
+c <month=null> | <month> calendar
 o8 | office && 8:00
 r8 | remote && 8:00

--- a/work_tracker/error.py
+++ b/work_tracker/error.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from work_tracker.command.command_manager import CommandManager
 from work_tracker.command.common import Command
-from .common import Date, Mode
+from .common import Date, Mode, classproperty
 
 
 class VersionCheckError(Exception):
@@ -17,8 +17,7 @@ class VersionCheckError(Exception):
 class CommandError(ABC):
     command_name: str
 
-    @property
-    @abstractmethod
+    @classproperty
     def message(self) -> str:
         raise NotImplementedError()
 
@@ -116,8 +115,7 @@ class ParserError(ABC):
     # error_start_index: int
     # error_end_index: int
 
-    @property
-    @abstractmethod
+    @classproperty
     def message(self) -> str:
         # return f"{self.raw_text}\n{' '*self.error_start_index + '^'*(self.error_end_index-self.error_start_index)}"
         raise NotImplementedError()

--- a/work_tracker/error.py
+++ b/work_tracker/error.py
@@ -30,7 +30,7 @@ class CommandErrorInvalidArgumentCount(CommandError):
     def message(self) -> str:
         expected_counts: list[int] = sorted({len(args) for args in CommandManager.get_command_by_name(self.command_name).valid_argument_types})
         formatted_counts: str = ', '.join(map(str, expected_counts[:-1])) + ((' or ' if len(expected_counts) > 1 else '') + str(expected_counts[-1]))
-        return f"invalid amount of arguments, received {self.received_argument_count} while {self.command_name} expects {formatted_counts}."
+        return f"invalid amount of arguments, received {self.received_argument_count} while '{self.command_name}' expects {formatted_counts}."
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,7 @@ class CommandErrorInvalidArgumentValue(CommandError):
 
     @property
     def message(self) -> str:
-        expected_value: str = self.expected_value if not isinstance(self.expected_value, list) else f"one of ({' '.join(self.expected_value)})"
+        expected_value: str = self.expected_value if not isinstance(self.expected_value, list) else f"one of ({', '.join(self.expected_value)})"
         return f"invalid argument value, received {self.received_value} expected {expected_value}."
 
 
@@ -76,19 +76,20 @@ class CommandErrorInvalidDateCount(CommandError):
 @dataclass(frozen=True)
 class CommandErrorInvalidMode(CommandError):
     mode: Mode
+    supported_modes: set[Mode] = None
 
     @property
     def message(self) -> str:
         command: Command = CommandManager.get_command_by_name(self.command_name)
-        supported_modes: list[Mode] = list(command.supported_modes)
+        supported_modes: list[Mode] = list(command.supported_modes) if self.supported_modes is None or len(self.supported_modes) == 0 else list(self.supported_modes)
         supported_modes.sort(key=lambda mode: mode.name)
 
         if len(supported_modes) == 1:
-            supported_modes_text: str = f"'{supported_modes[0].name}'"
+            supported_modes_text: str = f"'{supported_modes[0].name}' mode"
         else:
-            supported_modes_text: str = ", ".join(f"'{mode.name}'" for mode in supported_modes[:-1]) + f" or '{supported_modes[-1].name}'"
+            supported_modes_text: str = ", ".join(f"'{mode.name}'" for mode in supported_modes[:-1]) + f" and '{supported_modes[-1].name}' modes"
 
-        return f"invalid mode in which command was called, {self.command_name} works only in {supported_modes_text} mode but currently in '{self.mode.name}' mode."
+        return f"invalid mode in which command was called, this '{self.command_name}' command execution supports only {supported_modes_text} but currently in '{self.mode.name}' mode."
 
 
 @dataclass(frozen=True)
@@ -96,7 +97,7 @@ class CommandErrorNotImplemented(CommandError):
 
     @property
     def message(self) -> str:
-        return f"command {self.command_name} is not yet implemented."
+        return f"command '{self.command_name}' is not yet implemented."
 
 
 @dataclass(frozen=True)
@@ -137,7 +138,7 @@ class ParserErrorInvalidArgumentCount(ParserError):
     def message(self) -> str:
         expected_counts: list[int] = sorted({len(args) for args in self.command.valid_argument_types})
         formatted_counts: str = ', '.join(map(str, expected_counts[:-1])) + ((' or ' if len(expected_counts) > 1 else '') + str(expected_counts[-1]))
-        return f"invalid amount of arguments, received {self.received_amount} while {self.command.name} expects {formatted_counts}."
+        return f"invalid amount of arguments, received {self.received_amount} while command '{self.command.name}' expects {formatted_counts}."
 
 
 @dataclass(frozen=True)
@@ -153,7 +154,7 @@ class ParserErrorInvalidArgumentTypes(ParserError):
         ]
         formatted_types: str = ', '.join(valid_types[:-1]) + ((' or ' if len(valid_types) > 1 else '') + str(valid_types[-1]))
 
-        return f"invalid argument types, received {self._format_type_list(self.received_types)} while {self.command.name} expects {formatted_types}."
+        return f"invalid argument types, received {self._format_type_list(self.received_types)} while command '{self.command.name}' expects {formatted_types}."
 
     @staticmethod
     def _format_type_list(types: list[type]) -> str:

--- a/work_tracker/error.py
+++ b/work_tracker/error.py
@@ -127,14 +127,14 @@ class ParserError(ABC):
 class ParserErrorMultipleDates(ParserError):
     @property
     def message(self) -> str:
-        return f"multiple dates were provided without any command. To change the active date, provide only one."
+        return "multiple dates were provided without any command. To change the active date, provide only one."
 
 
 @dataclass(frozen=True)
 class ParserErrorMultipleDatesInvalidSyntax(ParserError):
     @property
     def message(self) -> str:
-        return f"multiple dates require corresponding opening and closing symbol at the start and end of list of dates."
+        return "multiple dates require corresponding opening and closing symbol at the start and end of list of dates."
 
 
 @dataclass(frozen=True)

--- a/work_tracker/error.py
+++ b/work_tracker/error.py
@@ -96,7 +96,6 @@ class CommandErrorInvalidMode(CommandError):
 
 @dataclass(frozen=True)
 class CommandErrorNotImplemented(CommandError):
-
     @property
     def message(self) -> str:
         return f"command '{self.command_name}' is not yet implemented."
@@ -129,6 +128,13 @@ class ParserErrorMultipleDates(ParserError):
     @property
     def message(self) -> str:
         return f"multiple dates were provided without any command. To change the active date, provide only one."
+
+
+@dataclass(frozen=True)
+class ParserErrorMultipleDatesInvalidSyntax(ParserError):
+    @property
+    def message(self) -> str:
+        return f"multiple dates require corresponding opening and closing symbol at the start and end of list of dates."
 
 
 @dataclass(frozen=True)

--- a/work_tracker/error.py
+++ b/work_tracker/error.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import difflib
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
+from types import UnionType
+from typing import get_args
 
 from work_tracker.command.command_manager import CommandManager
 from work_tracker.command.common import Command
@@ -156,12 +158,20 @@ class ParserErrorInvalidArgumentTypes(ParserError):
 
         return f"invalid argument types, received {self._format_type_list(self.received_types)} while command '{self.command.name}' expects {formatted_types}."
 
-    @staticmethod
-    def _format_type_list(types: list[type]) -> str:
-        if len(types) == 1:
-            return types[0].__name__
-        else:
-            return f"({', '.join(type_.__name__ for type_ in types)})"
+    @classmethod
+    def _get_name_from_type(cls, type_: type) -> str:
+        if isinstance(type_, UnionType):
+            return " | ".join(cls._get_name_from_type(arg) for arg in get_args(type_))
+
+        return type_.__name__
+
+    @classmethod
+    def _format_type_list(cls, types: list[type]) -> str:
+        names = [cls._get_name_from_type(type_) for type_ in types]
+        if len(names) == 1:
+            return names[0]
+
+        return f"({', '.join(names)})"
 
 
 @dataclass(frozen=True)

--- a/work_tracker/text/common.py
+++ b/work_tracker/text/common.py
@@ -170,7 +170,7 @@ def frame_text(
 
     padding: int = Config.data.output.frame.padding
     lines: list[str] = text.split("\n")
-    max_width: int = max([0] + [(minimal_line_width or 0)] + [(minimal_width or 0) - (padding*2 + 2)] + [len(strip_ansi(line)) for line in lines])
+    max_width: int = max([len(title or '') + padding*2 + Config.data.output.frame.title_padding*2 or 0] + [(minimal_line_width or 0)] + [(minimal_width or 0) - (padding*2 + 2)] + [len(strip_ansi(line)) for line in lines])
 
     if title is not None and not footer_title:
         title = f"{title_color.value}{' '*Config.data.output.frame.title_padding}{title}{' '*Config.data.output.frame.title_padding}{frame_color.value}"

--- a/work_tracker/text/common.py
+++ b/work_tracker/text/common.py
@@ -68,7 +68,7 @@ class Color(Enum): # TODO rethink these names
         try:
             if len(key) != 0 and "_" in key and key[0] != "_" and key[-1] != 0:
                 bg, rest = key.split("_", 1)
-                return Color[f"{bg.upper(), rest.capitalize()}"]
+                return Color[f"{bg.upper()}_{rest.capitalize()}"]
             else:
                 return Color[key.capitalize()]
         except KeyError:

--- a/work_tracker/text/input_command_completer.py
+++ b/work_tracker/text/input_command_completer.py
@@ -6,7 +6,6 @@ from work_tracker.common import month_map
 from work_tracker.config import Config
 
 
-# TODO make it work on backspace (might not be possible)
 class InputCommandCompleter(WordCompleter):
     def __init__(self):
         self.active: bool = True

--- a/work_tracker/text/input_output_handler.py
+++ b/work_tracker/text/input_output_handler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import colorama
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings
 
 from work_tracker.common import get_data_path
 from work_tracker.config import Config
@@ -14,9 +15,29 @@ class InputOutputHandler:
     def __init__(self):
         colorama.init()
         self._writer: TextWriter = TextWriter()
-        self.session: PromptSession = PromptSession(history=FileHistory(get_data_path().joinpath("cmd-history")))
+        self.session: PromptSession = self._initialize_session()
         self.command_completer: InputCommandCompleter = InputCommandCompleter()
         self._truncate_history()
+
+    def _initialize_session(self) -> PromptSession:
+        keybinds: KeyBindings = KeyBindings()
+
+        @keybinds.add('backspace')
+        def _(event):
+            buffer = event.app.current_buffer
+            if buffer.cursor_position > 0:
+                buffer.delete_before_cursor()
+
+            if self.command_completer.active and buffer.text:
+                buffer.start_completion(select_first=False)
+            elif not buffer.text:
+                buffer.cancel_completion()
+
+        return PromptSession(
+            history=FileHistory(get_data_path().joinpath("cmd-history")),
+            key_bindings=keybinds,
+            complete_while_typing=True
+        )
 
     @staticmethod
     def _truncate_history():

--- a/work_tracker/text/input_output_handler.py
+++ b/work_tracker/text/input_output_handler.py
@@ -49,7 +49,7 @@ class InputOutputHandler:
             lines: list[str] = file.readlines()
 
         with open(history_path, "w", newline="\n") as file:
-            file.writelines(lines[-Config.data.input.input_history_size*3:]) # 3 = size of one command
+            file.writelines(lines[-Config.data.input.history_size*3:]) # 3 = size of one command
 
     def input(self, prefix: str, show_autocomplete: bool = True, custom_autocomplete: list[str] = None) -> str:
         if custom_autocomplete is not None:

--- a/work_tracker/text/input_output_handler.py
+++ b/work_tracker/text/input_output_handler.py
@@ -49,7 +49,7 @@ class InputOutputHandler:
             lines: list[str] = file.readlines()
 
         with open(history_path, "w", newline="\n") as file:
-            file.writelines(lines[-50*3:]) # TODO config max history size constant, 3 size of one command
+            file.writelines(lines[-Config.data.input.input_history_size*3:]) # 3 = size of one command
 
     def input(self, prefix: str, show_autocomplete: bool = True, custom_autocomplete: list[str] = None) -> str:
         if custom_autocomplete is not None:

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 VERSION = __version__.split(".")

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 VERSION = __version__.split(".")

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.0rc3"
+__version__ = "0.2.0"
 VERSION = __version__.split(".")

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.0rc1"
+__version__ = "0.2.0rc2"
 VERSION = __version__.split(".")

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.0rc2"
+__version__ = "0.2.0rc3"
 VERSION = __version__.split(".")

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.0"
+__version__ = "0.2.0rc1"
 VERSION = __version__.split(".")

--- a/work_tracker/version.py
+++ b/work_tracker/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 VERSION = __version__.split(".")


### PR DESCRIPTION
# v0.2.0 Merge Request Summary

### Changes made:

#### New commands

- **`alias`** - lists all defined aliases, shows the replacement text for a specific alias, or creates/updates one. Aliases are user-defined text substitutions applied at parse time, allowing shorthand for any command or sequence of commands.
- **`deletealias`** - removes a previously defined alias by name.
- **`absence`** - marks a day or all workdays in a month as an absence. Replaces the previous behavior of `dayoff` for this purpose.
- **`present`** - removes the absence or day off status from a day or all workdays in a month, marking them as present.
- **`info`** - displays detailed information about a day or month, including attendance type, day type, work location, time at work, target time, and optionally work start and end times.
- **`keyword`** - lists all available keywords, their supported modes, current values, and descriptions.

#### Command changes

- **Modified `dayoff` command** - now exclusively marks a day or month as a day off (vacation), no longer serves double duty as an absence marker.
- **Modified `checkpoint` command** - accepts an optional `permanent` argument to create a permanent checkpoint that is not automatically removed when closing the app

#### New features

- **Alias system** - user-defined aliases are stored in `aliases.txt` and are substituted at parse time. Aliases can represent any text, including full command chains.
- **Keywords** - dynamic placeholders substituted at parse time with values derived from the current application state. Available keywords: `$today`, `$tomorrow`, `$yesterday`, `$nextday`, `$prevday`, `$month`, `$nextmonth`, `$prevmonth`. The keyword prefix is configurable.
- **Nullable macro arguments** - macro parameters can now be declared as optional with no default value, by providing 'null' as default argument value. This will result in an empty string during argument replacement.

#### Improvements

- **Optional repeat count for `undo` and `redo`** - both commands now accept an optional numeric argument specifying how many steps to undo or redo at once.
- **Configurable input history size** - the number of entries retained in the up/down arrow input history is now controlled by `input.history_size` in the config.
- **Multi-date delimiters moved to config** - the symbols used to open and close multi-date ranges (`(` and `)` by default) are now configurable via `input.date.multi_start_symbol` and `input.date.multi_end_symbol`.
- **Configurable date normalization** - date normalization (merging overlapping date ranges into a single range) is now disabled by default and can be toggled via `input.date.normalize` in the config.
- **Configurable error color** - the color used to display error messages can now be set via `output.error_color` in the config.
- **Configurable default values for `fte` and `rwr`** - default values for both commands are now exposed as `command.fte.default_value` and `command.rwr.default_value` in the config.
- **Improved `key` command output** - the warning displayed to the user now more precisely states the number of expected lines.
- **Improved macro date documentation** - the help text for macros now explicitly explains that dates provided before a macro call are forwarded to the commands inside the macro as if they were multi-dates.
- **Data and config version bumped to 2** - both the saved data format and the config format have been updated to version 2, with migration applied automatically on first launch after updating.

#### Bug fixes

- **Macros ignored dates provided before invocation** - dates specified before a macro call are now correctly forwarded to the commands inside the macro.
- **Macros accepted too many arguments** - the argument count check now enforces both the minimum and maximum expected count.
- **Macro default argument values were mutated** - missing copy of the `default_argument_values` list caused defaults to be overwritten across calls; fixed.
- **Crash in `fte full`** - resolved a crash caused by attempting to read the `.name` attribute of a `UnionType`, which does not have one.
- **`days` command used wrong argument type** - the command expected an `int` internally while its definition declared a `TimeArgument`; both are now consistent.
- **`holiday` changes did not update monthly target hours** - adding or removing a holiday now correctly recalculates the required hours for the month, unless the target was manually set by the user.
- **Autocomplete did not detect backspace** - added a global backspace keybind so that completion suggestions update correctly when characters are deleted.
- **Date parsing ambiguity with decimal-looking input** - input such as `2. 3h` was incorrectly parsed as `2.3h` instead of `3h on the 2nd`. Removed the ambiguous fallback that attempted time parsing before date parsing.
- **Multi-date range did not require a closing symbol** - the parser now requires the closing symbol when a multi-date range is opened.
- **Incorrect history entry for multi-date commands** - when a command was prefixed with multiple dates (e.g., `(24. 25.) office && target`), only the first command in a chain received the dates in the history record. Fixed.
- **Incorrect undo history when using macros** - macro execution now correctly records state history so that undo behaves as expected.
- **Background color config had no effect** - fixed incorrect enum value formatting when resolving background color from the config.
- **`clear` did not reset `work_start` and `work_end`** - the `reset()` method was missing those fields; they are now cleared correctly.
- **Passing `%` alone as a prefix caused a crash** - a bare `%` token is now correctly treated as a string rather than triggering a failed numeric cast.
- **Month names in uppercase were not recognized as dates** - date parsing is now case-insensitive for month names.
- **Invalid input changed the active date** - fixed an incorrectly structured conditional that was accepting partially invalid input and updating the active date anyway.
- **`zero`, `rwr`, `minutes`, and `days` commands failed with day-mode dates** - all four commands now handle day-specific dates correctly, consistent with their documented behavior.
- **`config` sub-field output was broken** - calling `config output.max_width` (or any dotted sub-field path) now correctly displays the requested field instead of failing silently.

#### Internal

- **Unit tests for every command** - each command now has a dedicated test file under `tests/commands/`. The parser has foundational coverage as well.
- **Python 3.14 support** - updated minimum required versions of dependencies where possible and changed the version constraint ruleset from `~=` to `>=`, including a `pydantic` bump to a version that supports Python 3.14.
- **Migrated to `uv`** - dependency management and packaging have been moved from plain `requirements.txt`, to `pyproject.toml` + `uv`.
- **Improved publish pipeline** - `publish.yaml` is now exclusively triggered manually and supports choosing between the test PyPI index and the official PyPI index.

---

And many other smaller bug fixes and changes that I lost track of. :)